### PR TITLE
add new path mapping option

### DIFF
--- a/useful-tools/AppRun-Qt
+++ b/useful-tools/AppRun-Qt
@@ -11,6 +11,7 @@ fi
 set -e
 
 CURRENTDIR="$(cd "${0%/*}" && echo "$PWD")"
+export CURRENTDIR
 BIN="${ARGV0:-$0}"
 BIN="${BIN##*/}"
 unset ARGV0

--- a/useful-tools/AppRun-generic
+++ b/useful-tools/AppRun-generic
@@ -12,6 +12,7 @@ fi
 set -e
 
 CURRENTDIR="$(cd "${0%/*}" && echo "$PWD")"
+export CURRENTDIR
 BIN="${ARGV0:-$0}"
 BIN="${BIN##*/}"
 unset ARGV0

--- a/useful-tools/path-mapping-hardcoded.hook
+++ b/useful-tools/path-mapping-hardcoded.hook
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# this script makes symnlinks to the hardcoded random dirs that were
+# patched away when 'PATH_MAPPING_HARDCODED' is used with quick-sharun
+
+if [ -f "$CURRENTDIR"/.env ]; then
+	. "$CURRENTDIR"/.env
+	[ -n "$_tmp_bin" ]   && ln -sfn "$CURRENTDIR"/bin    /tmp/"$_tmp_bin"
+	[ -n "$_tmp_lib" ]   && ln -sfn "$CURRENTDIR"/lib    /tmp/"$_tmp_lib"
+	[ -n "$_tmp_share" ] && ln -sfn "$CURRENTDIR"/share  /tmp/"$_tmp_share"
+fi
+

--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -374,6 +374,24 @@ elif [ "$PATH_MAPPING_RELATIVE" = 1 ]; then
 	echo 'SHARUN_WORKING_DIR=${SHARUN_DIR}' >> "$APPDIR"/.env
 	_echo "* Patched away /usr from binaries..."
 	echo ""
+elif [ "$PATH_MAPPING_HARDCODED" = 1 ]; then
+	_tmp_bin="$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 3)"
+	_tmp_lib="$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 3)"
+	_tmp_share="$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 5)"
+
+	sed -i \
+		-e "s|/usr/bin|/tmp/$_tmp_bin|g" \
+		-e "s|/usr/lib|/tmp/$_tmp_lib|g" \
+		-e "s|/usr/share|/tmp/$_tmp_share|g" \
+		"$APPDIR"/shared/bin/*
+
+	echo "_tmp_bin=$_tmp_bin" >> ./AppDir/.env
+	echo "_tmp_lib=$_tmp_lib" >> ./AppDir/.env
+	echo "_tmp_share=$_tmp_share" >> ./AppDir/.env
+	ADD_HOOKS="${ADD_HOOKS:+$ADD_HOOKS:}path-mapping-hardcoded.hook"
+
+	_echo "* Patched away /usr from binaries for random dirs in /tmp..."
+	echo ""
 fi
 
 if [ "$DEPLOY_DATADIR" = 1 ]; then


### PR DESCRIPTION
This one should only be used when `PATH_MAPPING` that uses ld-preload-open does not work and `PATH_MAPPING` relative is also not wanted due to it changing the current working dir. 

