### PR TITLE
Add Tagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The uruntime [automatically falls back to using namespaces](https://github.com/V
 [st](https://github.com/pkgforge-dev/st-AppImage)                                                                        |
 [strawberry](https://github.com/pkgforge-dev/strawberry-AppImage)                                                        |
 [Sudachi](https://github.com/pkgforge-dev/Sudachi-AppImage)                                                              |
+[Tagger](https://github.com/pkgforge-dev/Tagger-AppImage)                                                                |
 [Torzu](https://github.com/pkgforge-dev/Torzu-AppImage)                                                                  |
 [TouchHLE](https://github.com/pkgforge-dev/TouchHLE-AppImage)                                                            |
 [transmission-qt](https://github.com/pkgforge-dev/transmission-qt-AppImage)                                              |


### PR DESCRIPTION
`aarch64` fails to build due to some missing net dependencies