### PR TITLE
deploy dependencies of directories

### DIFF
--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -677,8 +677,10 @@ _make_deployment_array() {
 	# so we deploy any possible library and binary in the directories
 	# later on the binaries in lib will be wrapped with sharun
 	if [ -n "$ADD_DIR" ]; then
+		_echo "* Deploying directories:"
 		while read -r d; do
 			if [ -d "$d" ]; then
+				_echo " - $d"
 				set -- "$@" "$d"/*
 				for dd in "$d"/*; do
 					if [ -d "$dd" ]; then


### PR DESCRIPTION
cc @fiftydinar with this change you should be able to just pass `quick-sharun /path/to/dir` and it will automatically do the `/path/to/dir/*`

however this only goes one directory deep, so you will have `/path/to/dir/*` and `/path/to/dir/dir2/*` but not `/path/to/dir/dir2/dir3/*`

[I also added this check so that binaries in lib get wrapped with sharun automatically.](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/c0bfca5134de4b964c92d350ac9fd5383d2935fb/useful-tools/quick-sharun.sh#L1474-L1480)