### PR TITLE
Add Cartridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The uruntime [automatically falls back to using namespaces](https://github.com/V
 [Audio Sharing](https://github.com/pkgforge-dev/Audio-Sharing-AppImage)                                                  |
 [Authenticator](https://github.com/pkgforge-dev/Authenticator-AppImage)                                                  |
 [Azahar](https://github.com/pkgforge-dev/Azahar-AppImage-Enhanced)                                                       |
+[Cartridges](https://github.com/pkgforge-dev/Cartridges-AppImage)                                                        |
 [Cemu](https://github.com/pkgforge-dev/Cemu-AppImage-Enhanced)                                                           |
 [Citron](https://github.com/pkgforge-dev/Citron-AppImage)                                                                |
 [Clapper](https://github.com/pkgforge-dev/Clapper-AppImage)                                                              |


### PR DESCRIPTION
Only portable cache folder can be used, as everything else breaks the directory search for games, even when selecting the directory in file-picker afterwards saying it can't verify the directory. Persistent setting for selecting search entries is also broken this way.

Edit: Ok, maintainer updated the NewsFlash and Impression yesterday/today, whatever is the timezone, so that's great.

Cartridges was very outdated before, but now it's only outdated by 1 version, and that update just adds new keyboard shortcut dialog from Gnome 49, so nothing special.