### PR TITLE
Add Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The uruntime [automatically falls back to using namespaces](https://github.com/V
 [Rnote](https://github.com/pkgforge-dev/Rnote-AppImage)                                                                  |
 [rofi](https://github.com/pkgforge-dev/rofi-AppImage)                                                                    |
 [scrcpy](https://github.com/pkgforge-dev/scrcpy-AppImage)                                                                |
+[Secrets](https://github.com/pkgforge-dev/Secrets-AppImage)                                                              |
 [servo](https://github.com/pkgforge-dev/servo-AppImage)                                                                  |
 [sound-space-plus](https://github.com/pkgforge-dev/sound-space-plus-AppImage)                                            |
 [SpeedCrunch](https://github.com/pkgforge-dev/SpeedCrunch-AppImage)                                                      |


### PR DESCRIPTION
Works well, except it doesn't launch in Alpine.

In Alpine it complains about `yubikey` / `libusb` thing, which I'm not sure how to fix or it's a false trigger in Python yubikey, as it's not a requirement to use the application which can load keypass files just fine.