### PR TITLE
add vars to simplify hooks that need access to real locations

### DIFF
--- a/useful-tools/bin/AppRun-generic
+++ b/useful-tools/bin/AppRun-generic
@@ -19,6 +19,12 @@ export HOSTPATH="$PATH"
 export PATH="$APPDIR/bin:$PATH"
 export APPDIR
 
+export HOST_HOME="${REAL_HOME:-$HOME}"
+export HOST_XDG_CONFIG_HOME="${REAL_XDG_CONFIG_HOME:-${XDG_CONFIG_HOME:-$HOST_HOME/.config}}"
+export HOST_XDG_DATA_HOME="${REAL_XDG_DATA_HOME:-${XDG_DATA_HOME:-$HOST_HOME/.local/share}}"
+export HOST_XDG_CACHE_HOME="${REAL_XDG_CACHE_HOME:-${XDG_CACHE_HOME:-$HOST_HOME/.cache}}"
+export HOST_XDG_STATE_HOME="${REAL_XDG_STATE_HOME:-${XDG_STATE_HOME:-$HOST_HOME/.local/state}}"
+
 # Allow users to set env variables for specific AppImage
 # This feature only works with the uruntime
 if [ "$1" = '--appimage-add-env' ]; then


### PR DESCRIPTION
This should avoid stuff like [this](https://github.com/pkgforge-dev/Viber-AppImage-Enhanced/blob/9b6f4fafd3fba1e80620173b5932635b9ea35f41/AppDir/bin/autostart.src.hook#L7)

[flatpak uses these vars as well](https://docs.flatpak.org/en/latest/conventions.html#:~:text=These%20environment%20variables%20are%20always,also%20available%20on%20the%20host.)