### PR TITLE
make sure prevent sdl from loading libdecor when not bundled

### DIFF
--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -1722,13 +1722,14 @@ for lib do case "$lib" in
 		;;
 	*libdecor*.so*)
 		ADD_HOOKS="${ADD_HOOKS:+$ADD_HOOKS:}fix-gnome-csd.src.hook"
-		libdecor=1
 		;;
 	*libSDL*.so*)
 		# SDL may be bundled without libdecor since it maybe missing from the CI runner
-		# or the application makes use of GTK/Qt + SDL, in which case we do not need 
-		# libdecor at all, make sure SDL does not attempt to load libdecor in these cases
-		if [ "$libdecor" != 1 ]; then
+		# or the application makes of GTK/Qt + SDL, in which case we do not need libdecor
+		# at all, make sure SDL does not attempt to load libdecor in these cases
+		if [ -f "$APPDIR"/shared/lib/libdecor-0.so.0 ]; then
+			continue
+		elif grep -aoq -m 1 'libdecor-0.so.0' "$lib"; then
 			sed -i -e 's|libdecor-0.so.0|fuck-gnome.so.X|g' "$lib"
 		fi
 		;;


### PR DESCRIPTION
There doesn't seem to be a way to disable this from sdl other than recompiling the library which is not feasible. 

Crazy that nobody reported this beforehand: https://github.com/libsdl-org/SDL/issues/14887



