### PR TITLE
add `aerofoil`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | ------------------------------------------------------------------------------------------------------------------------ |
 [12to11](https://github.com/pkgforge-dev/12to11-AppImage)                                                                |
 [AAAAXY](https://github.com/pkgforge-dev/AAAAXY-AppImage-Enhanced)                                                       |
+[Aerofoil](https://github.com/pkgforge-dev/Aerofoil-AppImage)                                                            |
 [alacritty](https://github.com/pkgforge-dev/alacritty-AppImage)                                                          |
 [Android Tools](https://github.com/pkgforge-dev/android-tools-AppImage)                                                  |
 [Android Translation Layer](https://github.com/pkgforge-dev/android_translation_layer-AppImage)                          |


### PR DESCRIPTION
Just tested but only on glibc system and it's woking.
But there's some caveats, dev hardcoded the path structure to like
/bin/AerofoilX
/lib/aerofoil/Package/*.gpf game assets
/lib/aerofoil/tools required to make it work

I made a mess inside `make-appimage.sh` until it worked, maybe there's a better way to do
another thing it's using /tmp/ dir to store the configs and savegame, when user restarts pc will loose all its progress and settings lol
and I tried already the trick /AppDir/bin/change-working-dir.src.hook
```
dir=${XDG_CONFIG_HOME:-~/.config}/aerofoil
mkdir -p "$dir"
cd "$dir"
```