### PR TITLE
add the option to block dlopening certain libraries

### DIFF
--- a/useful-tools/lib/anylinux.c
+++ b/useful-tools/lib/anylinux.c
@@ -305,6 +305,10 @@ VISIBLE void *dlopen(const char *filename, int flags) {
 	// NULL filename means the caller wants a handle to the main program
 	if (filename && should_block_library(filename)) {
 		DEBUG_PRINT("Blocked dlopen of '%s' (matched ANYLINUX_DO_NOT_LOAD_LIBS)\n", filename);
+		// We must make dlerror() return a proper error string after returning NULL
+		// If dlerror() returns NULL here the caller will segfault on the string format.
+		// Trigger a real dlopen failure so the dynamic linker sets the error state.
+		(void)dlopen_orig("/anylinux_blocked_lib_that_does_not_exist.so", RTLD_NOW);
 		return NULL;
 	}
 


### PR DESCRIPTION
After https://github.com/libsdl-org/SDL/issues/14887 we may want to have a better method to block certain libraries from loading.

For example: 

* gtk3 apps sometimes need to dlopen mesa for some reason, even though it is not needed for their operation at all (gtk3 is not hardware accelerated) and work fine when not found, but if mesa is not added then they will try to dlopen the mesa of the host which can cause a crash.

* Many qt6 and gtk4 apps work fine without hardware accel, [example](https://github.com/pkgforge-dev/Keypunch-AppImage/pull/5)

* [This app](https://github.com/pkgforge-dev/SuperTux-AppImage-Enhanced) for some reason always tries to dlopen pipewire ignoring the `SDL_AUDIO_DRIVER` env vars, it works perfectly fine when it doesn't find it.

