### PR TITLE
add `sonic3air`

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Signal](https://github.com/pkgforge-dev/Signal-AppImage-Enhanced)                                                       |
 [Snes9x](https://github.com/pkgforge-dev/Snes9x-AppImage-Enhanced)                                                       |
 [soh](https://github.com/pkgforge-dev/soh-AppImage-Enhanced)                                                             |
+[Sonic 3 A.I.R.](https://github.com/pkgforge-dev/Sonic-3-AIR-AppImage)                                                   |
 [Sonic-Mania-Decompilation](https://github.com/pkgforge-dev/Sonic-Mania-Decompilation-AppImage)                          |
 [sound-space-plus](https://github.com/pkgforge-dev/sound-space-plus-AppImage)                                            |
 [spacecadetpinball](https://github.com/pkgforge-dev/spacecadetpinball-AppImage)                                          |


### PR DESCRIPTION
So this one was rough to make it work, the only good version that works is v24.12.05.0, apparently dev get lost somewhere with the linux port, trying to compile main branch from github repo, it compiles but game is very broken and crashes a lot, this version v24.12.05.0 is the last good one working, I left a skeleton for aarch64 platform because I'd like to still try to make this stable version to compile for this platform but is failing to compile with some error about failed to compile static SDL2 maybe because of the recently issue of SDL3 that got reverted I don't know but still would like to try on next days. Maybe would have better way to manipulate the files that I sent to AppDir/bin folder, but I don't know, it just works (todd howard)

Tried on alpine distrobox and it worked too.