### PR TITLE
add `whatsdesk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [virt-manager](https://github.com/pkgforge-dev/virt-manager-AppImage)                                                    |
 [Warp](https://github.com/pkgforge-dev/Warp-AppImage)                                                                    |
 [Webcamoid](https://github.com/pkgforge-dev/Webcamoid-AppImage)                                                          |
+[WhatsDesk](https://github.com/pkgforge-dev/WhatsDesk-AppImage)                                                          |
 [wine](https://github.com/pkgforge-dev/wine-AppImage)                                                                    |
 [wipEout-Rewrite](https://github.com/pkgforge-dev/wipEout-Rewrite-AppImage)                                              |
 [Xash3D-FWGS](https://github.com/pkgforge-dev/Xash3D-FWGS-AppImage-Enhanced)                                             |


### PR DESCRIPTION
Despite your discontent with electron apps (I don't like electron either), an appimage is an appimage. I don't know if it was really necessary to install all that packages though.

To compensate, when I get some free time maybe I try to make an appimage for ferdium then.