### PR TITLE
add `nestopia`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Mousai](https://github.com/pkgforge-dev/Mousai-AppImage)                                                                |
 [mpv](https://github.com/pkgforge-dev/mpv-AppImage)                                                                      |
 [NBlood](https://github.com/pkgforge-dev/NBlood-AppImage)                                                                |
+[Nestopia](https://github.com/pkgforge-dev/Nestopia-AppImage)                                                            |
 [NewsFlash](https://github.com/pkgforge-dev/NewsFlash-AppImage)                                                          |
 [Nomacs](https://github.com/pkgforge-dev/Nomacs-AppImage)                                                                |
 [NSZ](https://github.com/pkgforge-dev/NSZ-AppImage)                                                                      |


### PR DESCRIPTION
Tested on distrobox alpine too
~~need to fix wmclass though~~ fixed, I put the one wayland uses nestopia, x11 shows Nestopia instead