### PR TITLE
add `ymir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Xash3D-FWGS](https://github.com/pkgforge-dev/Xash3D-FWGS-AppImage-Enhanced)                                             |
 [xenia-canary](https://github.com/pkgforge-dev/xenia-canary-AppImage)                                                    |
 [xoreos](https://github.com/pkgforge-dev/xoreos-AppImage)                                                                |
+[Ymir](https://github.com/pkgforge-dev/Ymir-AppImage)                                                                    |
 [ZapZap](https://github.com/pkgforge-dev/ZapZap-AppImage-Enhanced)                                                       |
 [Zenity](https://github.com/pkgforge-dev/Zenity-GTK3-AppImage)                                                           |
 


### PR DESCRIPTION
tested on distrobox alpine, it works there too.
this project developer decided to use vcpkg, didn't like it because it's compiling its modules debug and release versions and it's taking a while to compile because of that and already tried VCPKG_BUILD_TYPE=release and no dice, I want to try a branch to make it use the ones provided by arch should be possible, just need to fix rtmidi that cmake is not finding it.