### PR TITLE
add `neverball` and `REDRIVER2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [mpv](https://github.com/pkgforge-dev/mpv-AppImage)                                                                      |
 [NBlood](https://github.com/pkgforge-dev/NBlood-AppImage)                                                                |
 [Nestopia](https://github.com/pkgforge-dev/Nestopia-AppImage)                                                            |
-[Neverbal](https://github.com/pkgforge-dev/Neverball-AppImage)                                                           |
+[Neverball](https://github.com/pkgforge-dev/Neverball-AppImage)                                                           |
 [NewsFlash](https://github.com/pkgforge-dev/NewsFlash-AppImage)                                                          |
 [Nomacs](https://github.com/pkgforge-dev/Nomacs-AppImage)                                                                |
 [NSZ](https://github.com/pkgforge-dev/NSZ-AppImage)                                                                      |


### PR DESCRIPTION
tested them on distrobox alpine, despite redriver2 inside alpine container is not finding the directory for game data, weird (despite I had another game with same behaviour but could try on postmarketOS and worked there fine, maybe something with the distrobox container?), and can't test on arm64 this one since is broken for now, will try to make it compile for arm64 later

and I had to disable the --test, neverball about sound and redriver2 don't remember now what it was about