### PR TITLE
add `bindtextdomain` override to `anylinux.so` and fix wrong unsetenv

### DIFF
--- a/useful-tools/lib/anylinux.c
+++ b/useful-tools/lib/anylinux.c
@@ -55,7 +55,7 @@ static void spoof_argv0(int argc, char **argv) {
 	if (new_argv0 && *new_argv0) {
 		DEBUG_PRINT("Overriding argv[0] from '%s' to '%s'\n", argv[0], new_argv0);
 		argv[0] = (char *)new_argv0;
-		unsetenv("ANYLINUX_ARGV0");
+		unsetenv("OVERRIDE_ARGV0");
 	}
 }
 


### PR DESCRIPTION
This way we don't rely on the random symlinks in `/tmp` to get working localization. 

Inspired by snap doing a similar trick. 

