### PR TITLE
add `clksignal` and `xiphos`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Clapper](https://github.com/pkgforge-dev/Clapper-AppImage)                                                              |
 [ClassiCube](https://github.com/pkgforge-dev/ClassiCube-AppImage)                                                        |
 [Clementine](https://github.com/pkgforge-dev/Clementine-AppImage)                                                        |
+[Clock Signal](https://github.com/pkgforge-dev/CLK-AppImage)                                                             |
 [ClownMDEmu](https://github.com/pkgforge-dev/ClownMDEmu-AppImage)                                                        |
 [Collision](https://github.com/pkgforge-dev/Collision-AppImage)                                                          |
 [CorsixTH](https://github.com/pkgforge-dev/CorsixTH-AppImage)                                                            |
@@ -233,6 +234,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [wipEout-Rewrite](https://github.com/pkgforge-dev/wipEout-Rewrite-AppImage)                                              |
 [Xash3D-FWGS](https://github.com/pkgforge-dev/Xash3D-FWGS-AppImage-Enhanced)                                             |
 [xenia-canary](https://github.com/pkgforge-dev/xenia-canary-AppImage)                                                    |
+[Xiphos](https://github.com/pkgforge-dev/Xiphos-AppImage)                                                                |
 [xoreos](https://github.com/pkgforge-dev/xoreos-AppImage)                                                                |
 [Ymir](https://github.com/pkgforge-dev/Ymir-AppImage)                                                                    |
 [ZapZap](https://github.com/pkgforge-dev/ZapZap-AppImage-Enhanced)                                                       |


### PR DESCRIPTION
Tested both on distrobox alpine
I don't know what's the deal with Xiphos, when open first time it complains that couldn't create .sword directory and closes. If you try to open it again, it creates this directory and the app simply works!