### PR TITLE
add `cuberite` and `itgmania`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Impression](https://github.com/pkgforge-dev/Impression-AppImage)                                                        |
 [ioquake3](https://github.com/pkgforge-dev/ioquake3-AppImage)                                                            |
 [isle-portable](https://github.com/pkgforge-dev/isle-portable-AppImage-Enhanced)                                         |
+[ITGmania](https://github.com/pkgforge-dev/ITGmania-AppImage)                                                            |
 [kaffeine](https://github.com/pkgforge-dev/kaffeine-AppImage)                                                            |
 [kdeconnect](https://github.com/pkgforge-dev/kdeconnect-AppImage)                                                        |
 [kdenlive](https://github.com/pkgforge-dev/kdenlive-AppImage-Enhanced)                                                   |


### PR DESCRIPTION
Cuberite is minecraft server written in cpp
It only supports from minecraft 1.8 up to 1.12

There's cuberite-git on AUR, but couldn't make it work, it failed and without any error msg on github actions, maybe because it tries to use systemd? I don't know.

Then I just used the already compiled provided from official cuberite webpage and that one worked to host server trough the appimage

ITGmania tested on distrobox alpine, this one only -git version of AUR compiled, the "stable" from AUR had issues to compile aarch64 version