### PR TITLE
do not install debloated llvm by default

### DIFF
--- a/useful-tools/get-debloated-pkgs.sh
+++ b/useful-tools/get-debloated-pkgs.sh
@@ -217,8 +217,7 @@ if [ "$COMMON_PACKAGES" = 1 ]; then
 		gtk3-mini        \
 		gtk4-mini        \
 		gdk-pixbuf2-mini \
-		librsvg-mini     \
-		llvm-libs-"$PKG_TYPE"
+		librsvg-mini
 fi
 
 if [ "$ADD_MESA" = 1 ]; then


### PR DESCRIPTION
With `mesa-{mini,nano}` no longer depending on LLVM, this package has become rarely needed and just [causes more issues](https://github.com/search?q=org%3Apkgforge-dev%20%22!%20llvm%22&type=code) than it solves now.

removing it also makes it less likely it for CIs to fail due to github rate limits.

cc @Link4Electronics  @fiftydinar  @crueter 

