### PR TITLE
add duckstation-gpl and gearEMUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Fretboard](https://github.com/pkgforge-dev/Fretboard-AppImage)                                                          |
 [Gapless](https://github.com/pkgforge-dev/Gapless-AppImage)                                                              |
 [Gear Lever](https://github.com/pkgforge-dev/Gear-Lever-AppImage)                                                        |
-[Gearcoleco](https://github.com/pkgforge-dev/Gearcoleco-AppImage)                                                        |
 [Geargrafx](https://github.com/pkgforge-dev/Geargrafx-AppImage)                                                          |
 [Gearlynx](https://github.com/pkgforge-dev/Gearlynx-AppImage)                                                            |
 [Gearsystem](https://github.com/pkgforge-dev/Gearsystem-AppImage)                                                        |


### PR DESCRIPTION
Since I suspect you're a bird person, here the mallardstation lol
Vulkan works on glibc, but on distrobox alpine vulkan is broken, says didn't find any gpu capable
you may check the aur https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=duckstation
it compiles and uses specific shaderc version since it's an old release of duckstation

I plan to make all gear emulators, gearsystem, gearcoleco, geargrafx, gearboy too
gearlynx working on alpine