### PR TITLE
add maniadrive and simitone

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Secrets](https://github.com/pkgforge-dev/Secrets-AppImage)                                                              |
 [servo](https://github.com/pkgforge-dev/servo-AppImage)                                                                  |
 [Signal](https://github.com/pkgforge-dev/Signal-AppImage-Enhanced)                                                       |
+[Simitone](https://github.com/pkgforge-dev/Simitone-AppImage)                                                            |
 [Snes9x](https://github.com/pkgforge-dev/Snes9x-AppImage-Enhanced)                                                       |
 [soh](https://github.com/pkgforge-dev/soh-AppImage-Enhanced)                                                             |
 [Sonic 3 A.I.R.](https://github.com/pkgforge-dev/Sonic-3-AIR-AppImage)                                                   |


### PR DESCRIPTION
tested on alpine disrobox and works

this was an informal request from a friend, tried to make arm64 version to work since he owns a smartphone with sailfishOS which uses sxmos as DE, but couldn't make arm64 to compile, fails when tries to compile ODE through its own script

But he tested x86_64 release and approved lol


Simitone, source port of the sims1 that uses dotnet and will ask for game assets when running appimage
works fine on glibc, but on alpine distrobox
```
[ALSOFT] (WW) Failed to load libpipewire-0.3.so.0
[ALSOFT] (WW) Failed to initialize backend "pipewire"
[ALSOFT] (WW) Failed to load libpulse.so.0
[ALSOFT] (WW) Failed to initialize backend "pulse"
[ALSOFT] (WW) Failed to load libasound.so.2
[ALSOFT] (WW) Failed to initialize backend "alsa"
[ALSOFT] (WW) Failed to open playback device: Could not open /dev/dsp: No such file or directory
[ALSOFT] (WW) Error generated on device (nil), code 0xa004
=== FATAL ERROR ===
A fatal error occurred! Please report this issue on GitHub or Discord.
```
and crashes

I checked the APPIMAGE_DEBUG on my system and didn't call for pipewire for sound to work, but on alpine distrobox is giving this issue, should add pipewire-audio and pipewire-jack?