### PR TITLE
add mixxx qtcreator and readest

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Qimgv](https://github.com/pkgforge-dev/Qimgv-AppImage)                                                                  |
 [QtCreator](https://github.com/pkgforge-dev/QtCreator-AppImage)                                                          |
 [QTerminal](https://github.com/pkgforge-dev/QTerminal-AppImage)                                                          |
+[Readest](https://github.com/pkgforge-dev/Readest-AppImage-Enhanced)                                                     |
 [Reco](https://github.com/pkgforge-dev/Reco-AppImage)                                                                    |
 [Rednukem](https://github.com/pkgforge-dev/Rednukem-AppImage)                                                            |
 [REDRIVER2](https://github.com/pkgforge-dev/REDRIVER2-AppImage)                                                          |


### PR DESCRIPTION
tested both on alpine and worked fine, they're qt apps
Mixxx for aarch64 had to disable it beacuse it was compiled agains an old version of protobug-lite lib, is there a way to force to compile the PKGBUILD from official arch repo (arch x86_64 or arch alarm official repos)? I know it's possible to do for AUR