### PR TITLE
add multiple apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 [Reco](https://github.com/pkgforge-dev/Reco-AppImage)                                                                    |
 [Rednukem](https://github.com/pkgforge-dev/Rednukem-AppImage)                                                            |
 [REDRIVER2](https://github.com/pkgforge-dev/REDRIVER2-AppImage)                                                          |
-[RenPy](https://github.com/pkgforge-dev/RenPy-AppImage)                                                                  |
 [Rewaita](https://github.com/pkgforge-dev/Rewaita-AppImage)                                                              |
 [RigelEngine](https://github.com/pkgforge-dev/RigelEngine-AppImage)                                                      |
 [Riseup-VPN](https://github.com/pkgforge-dev/Riseup-VPN-AppImage)                                                        |


### PR DESCRIPTION
Fix https://github.com/pkgforge-dev/Anylinux-AppImages/issues/432
tried all of them alpine distrobox and worked, only that doesn't seem to be 100% is renpy (which uses your favorite python language), feels like it doesn't have access for writing it wants to write to the mountpoint of appiamge, maybe do a hook to change to $HOME/.renpy ? despite that the game/visual novel maker works but everytime user reopens it, it didn't stored any settings.

sayonara-player is a request from dCo3lh0