### PR TITLE
fix udev hook

### DIFF
--- a/useful-tools/hooks/udev-installer.hook
+++ b/useful-tools/hooks/udev-installer.hook
@@ -51,11 +51,7 @@ _is_rule_already_installed() {
 	done
 
 	# bundled udev rules are already installed if the array is empty
-	if [ -z "$1" ]; then
-		return 0
-	else
-		return 1
-	fi
+	[ -n "$1" ] || return 1
 }
 
 _install_udev() {
@@ -79,8 +75,8 @@ _install_udev() {
 }
 
 install_udev_rules() {
-	_udev_installer_check
-	_is_rule_already_installed
+	_udev_installer_check || return 0
+	_is_rule_already_installed || return 0
 	if notify --display-question "$_udev_install_msg"; then
 		_install_udev
 	else


### PR DESCRIPTION
there were two bugs here, one the logic in the check for empty array was flipped. It was returning 0 when empty. 

The other bug is that running `install_udev_rules || :`, the `|| :` somehow causes the function to disable `set -e`, since it would continue even when `_udev_installer_check` or `_is_rule_already_installed` failed!!

I didn't know shell had this behaviour: 

<img width="270" height="318" alt="image" src="https://github.com/user-attachments/assets/2763bb4f-cf9c-4dc6-97b3-7207c67b477b" />
