### PR TITLE
`quick-sharun`(certs-check): Fix TLS certificates not found in Fedora 44

### DIFF
--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -1290,6 +1290,7 @@ _add_p11kit_cert_hook() {
 	  /etc/pki/tls/cert.pem
 	  /etc/pki/tls/cacert.pem
 	  /etc/ssl/cert.pem
+	  /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 	  /var/lib/ca-certificates/ca-bundle.pem
 	'
 


### PR DESCRIPTION
Fedora 44 changed the location for root pki/ssl certificate to `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`, as outlined here:

https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile