### PR TITLE
add 4 apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [OpenBoardView](https://github.com/pkgforge-dev/OpenBoardView-AppImage) |
 | [OpenClaw](https://github.com/pkgforge-dev/OpenClaw-AppImage) |
 | [opencode](https://github.com/pkgforge-dev/opencode-AppImage-Enhanced) |
+| [OpenGothic](https://github.com/pkgforge-dev/OpenGothic-AppImage) |
 | [OpenJazz](https://github.com/pkgforge-dev/OpenJazz-AppImage) |
 | [OpenLara](https://github.com/pkgforge-dev/OpenLara-AppImage) |
 | [OpenLoco](https://github.com/pkgforge-dev/OpenLoco-AppImage) |

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [KiCad](https://github.com/pkgforge-dev/KiCad-AppImage) |
 | [Kid3](https://github.com/pkgforge-dev/Kid3-AppImage) |
 | [Knights](https://github.com/pkgforge-dev/Knights-AppImage) |
+| [KolourPaint](https://github.com/pkgforge-dev/KolourPaint-AppImage) |
 | [KPatience](https://github.com/pkgforge-dev/KPatience-AppImage) |
 | [Kronos](https://github.com/pkgforge-dev/Kronos-AppImage) |
 | [Ladybird](https://github.com/pkgforge-dev/ladybird-appimage) |
@@ -304,6 +305,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [Ruffle](https://github.com/pkgforge-dev/Ruffle-AppImage) |
 | [RustDesk](https://github.com/pkgforge-dev/RustDesk-AppImage-Enhanced) |
 | [RVGL](https://github.com/pkgforge-dev/RVGL-AppImage) |
+| [SACDExtractGUI](https://github.com/pkgforge-dev/SACDExtractGUI-AppImage) |
 | [Sanicball](https://github.com/pkgforge-dev/Sanicball-AppImage) |
 | [Satty](https://github.com/pkgforge-dev/Satty-AppImage) |
 | [Sayonara-Player](https://github.com/pkgforge-dev/Sayonara-Player-AppImage-Enhanced) |
@@ -317,6 +319,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [Simitone](https://github.com/pkgforge-dev/Simitone-AppImage) |
 | [SimpleX Chat](https://github.com/pkgforge-dev/SimpleX-Chat-AppImage-Enhanced) |
 | [Simutrans](https://github.com/pkgforge-dev/Simutrans-AppImage) |
+| [SkyEmu](https://github.com/pkgforge-dev/SkyEmu-AppImage) |
 | [Slack](https://github.com/pkgforge-dev/Slack-AppImage) |
 | [Snes9x](https://github.com/pkgforge-dev/Snes9x-AppImage-Enhanced) |
 | [SongRec](https://github.com/pkgforge-dev/SongRec-AppImage) |


### PR DESCRIPTION
fixes https://github.com/pkgforge-dev/Anylinux-AppImages/issues/524

skyemu wants pipewire tho, it uses sokol for rendering instead of sdl, sdl2 is being used for input only, and sokol is the one asking for pipewire_pcm and there's more, it doesn't provide a Window Class, it's empty

OpenGothic is vulkan only, but needs game assets, and this one I was preparing the script for stable releases, but stable not worth trying to compile rn, will wait for their next stable release