### PR TITLE
Add `Streamlink`

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [Stella](https://github.com/pkgforge-dev/Stella-AppImage) |
 | [stirling-pdf](https://github.com/pkgforge-dev/Stirling-PDF-AppImage) |
 | [strawberry](https://github.com/pkgforge-dev/strawberry-AppImage) |
+| [Streamlink](https://github.com/pkgforge-dev/Streamlink-AppImage) |
 | [Sudachi](https://github.com/pkgforge-dev/Sudachi-AppImage) |
 | [Super Mario War](https://github.com/pkgforge-dev/Supermariowar-AppImage) |
 | [Supermodel](https://github.com/pkgforge-dev/Supermodel-AppImage) |


### PR DESCRIPTION
Streamlink is a tool for watching video streams from services like kick and twitch from the terminal, it doesn't have any GUI, an example usage would be:
`streamlink kick.com/sigmatiktoker1959 360p --player mpv`

<img width="828" height="609" alt="image" src="https://github.com/user-attachments/assets/5cce36dc-d4d7-4046-bcb5-c40105e39222" />
