### PR TITLE
make sure electron bundled libs load first

### DIFF
--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -844,6 +844,9 @@ _make_deployment_array() {
 				fi
 			done
 		fi
+		# electron bundled libs always need to load first
+		# for example libcef.so may need to read a icudtl.dat next to it
+		echo 'SHARUN_EXTRA_LIBRARY_PATH=${SHARUN_DIR}/bin:${SHARUN_EXTRA_LIBRARY_PATH}' >> "$APPENV"
 	fi
 	if [ "$DEPLOY_OPENGL" = 1 ] || [ "$DEPLOY_VULKAN" = 1 ]; then
 		DEPLOY_COMMON_LIBS=${DEPLOY_COMMON_LIBS:-1}


### PR DESCRIPTION
cc @fiftydinar @Link4Electronics 

I found this bug when making an appimage of OpenHuman. 

Weird this is the first app that ran into this issue.

It should no break anything for existing electron appimages, but be aware just in case.