### PR TITLE
support GTK2 deployment, add `gtk2-ng` demo

### DIFF
--- a/.github/workflows/build-demos.yml
+++ b/.github/workflows/build-demos.yml
@@ -51,6 +51,12 @@ jobs:
             script: gtk4-demo-onlysoftware-appimage
           - arch: x86_64
             runs-on: ubuntu-24.04
+            script: gtk2-demo-appimage
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+            script: gtk2-demo-appimage
+          - arch: x86_64
+            runs-on: ubuntu-24.04
             script: qt6-dbus-demo-appimage
           - arch: aarch64
             runs-on: ubuntu-24.04-arm

--- a/useful-tools/demo/gtk2-demo-appimage.sh
+++ b/useful-tools/demo/gtk2-demo-appimage.sh
@@ -17,7 +17,6 @@ export MAIN_BIN=gtk-demo
 
 pacman -Syu --noconfirm \
 	base-devel       \
-	curl             \
 	git              \
 	libxcb           \
 	libxcursor       \
@@ -26,8 +25,6 @@ pacman -Syu --noconfirm \
 	libxkbcommon-x11 \
 	libxrandr        \
 	libxtst          \
-	mesa-utils       \
-	vulkan-tools     \
 	wget             \
 	xorg-server-xvfb \
 	zsync

--- a/useful-tools/demo/gtk2-demo-appimage.sh
+++ b/useful-tools/demo/gtk2-demo-appimage.sh
@@ -48,7 +48,7 @@ echo "Bundling AppImage..."
 echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
 chmod +x ./quick-sharun
-./quick-sharun /usr/bin/gtk-demo*
+./quick-sharun /usr/bin/gtk-demo* /usr/share/gtk-2.0/demo
 
 ./quick-sharun --make-appimage
 

--- a/useful-tools/demo/gtk2-demo-appimage.sh
+++ b/useful-tools/demo/gtk2-demo-appimage.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# Demonstration that bundles gtk2 demo app from gtk2-ng
+
+set -eux
+
+ARCH="$(uname -m)"
+SHARUN="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/quick-sharun.sh"
+AUR="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/make-aur-package.sh"
+EXTRA_PACKAGES="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/get-debloated-pkgs.sh"
+
+export ICON=DUMMY
+export DESKTOP=DUMMY
+export OUTPATH=./dist
+export OUTNAME=gtk2-ng-demo-"$ARCH".AppImage
+export MAIN_BIN=gtk-demo
+
+pacman -Syu --noconfirm \
+	base-devel       \
+	curl             \
+	git              \
+	libxcb           \
+	libxcursor       \
+	libxi            \
+	libxkbcommon     \
+	libxkbcommon-x11 \
+	libxrandr        \
+	libxtst          \
+	mesa-utils       \
+	vulkan-tools     \
+	wget             \
+	xorg-server-xvfb \
+	zsync
+
+echo "Building gtk2-ng aur package..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$AUR" -O ./make-aur-package.sh
+chmod +x ./make-aur-package.sh
+./make-aur-package.sh gtk2-ng-git
+
+echo "Installing debloated packages..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
+chmod +x ./get-debloated-pkgs.sh
+./get-debloated-pkgs.sh --add-common --prefer-nano
+
+echo "Bundling AppImage..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
+chmod +x ./quick-sharun
+./quick-sharun /usr/bin/gtk-demo*
+
+./quick-sharun --make-appimage
+
+# test the final app
+./quick-sharun --test ./dist/*.AppImage

--- a/useful-tools/demo/gtk3-demo-appimage.sh
+++ b/useful-tools/demo/gtk3-demo-appimage.sh
@@ -15,7 +15,6 @@ export OUTNAME=gtk3-demo-"$ARCH".AppImage
 
 pacman -Syu --noconfirm \
 	base-devel       \
-	curl             \
 	git              \
 	gtk3-demos       \
 	libxcb           \
@@ -25,8 +24,6 @@ pacman -Syu --noconfirm \
 	libxkbcommon-x11 \
 	libxrandr        \
 	libxtst          \
-	mesa-utils       \
-	vulkan-tools     \
 	wget             \
 	xorg-server-xvfb \
 	zsync

--- a/useful-tools/demo/gtk4-demo-appimage.sh
+++ b/useful-tools/demo/gtk4-demo-appimage.sh
@@ -17,7 +17,6 @@ export GTK_CLASS_FIX=1
 
 pacman -Syu --noconfirm \
 	base-devel       \
-	curl             \
 	git              \
 	gtk4-demos       \
 	libxcb           \
@@ -27,8 +26,6 @@ pacman -Syu --noconfirm \
 	libxkbcommon-x11 \
 	libxrandr        \
 	libxtst          \
-	mesa-utils       \
-	vulkan-tools     \
 	wget             \
 	xorg-server-xvfb \
 	zsync

--- a/useful-tools/demo/gtk4-demo-onlysoftware-appimage.sh
+++ b/useful-tools/demo/gtk4-demo-onlysoftware-appimage.sh
@@ -22,7 +22,6 @@ export ALWAYS_SOFTWARE=1
 
 pacman -Syu --noconfirm \
 	base-devel       \
-	curl             \
 	git              \
 	gtk4-demos       \
 	libxcb           \
@@ -32,8 +31,6 @@ pacman -Syu --noconfirm \
 	libxkbcommon-x11 \
 	libxrandr        \
 	libxtst          \
-	mesa-utils       \
-	vulkan-tools     \
 	wget             \
 	xorg-server-xvfb \
 	zsync

--- a/useful-tools/demo/qt6-dbus-demo-appimage.sh
+++ b/useful-tools/demo/qt6-dbus-demo-appimage.sh
@@ -16,7 +16,6 @@ export OUTNAME=Qt6+dbus-demo-"$ARCH".AppImage
 
 pacman -Syu --noconfirm \
 	base-devel       \
-	curl             \
 	git              \
 	kvantum          \
 	libxcb           \
@@ -27,10 +26,8 @@ pacman -Syu --noconfirm \
 	libxrandr        \
 	libxtst          \
 	lxqt-qtplugin    \
-	mesa-utils       \
 	qt6ct            \
 	qt6-tools        \
-	vulkan-tools     \
 	wget             \
 	xorg-server-xvfb \
 	zsync

--- a/useful-tools/demo/qt6-dbus-demo-onlysoftware-appimage.sh
+++ b/useful-tools/demo/qt6-dbus-demo-onlysoftware-appimage.sh
@@ -21,7 +21,6 @@ export ALWAYS_SOFTWARE=1
 
 pacman -Syu --noconfirm \
 	base-devel       \
-	curl             \
 	git              \
 	kvantum          \
 	libxcb           \
@@ -32,10 +31,8 @@ pacman -Syu --noconfirm \
 	libxrandr        \
 	libxtst          \
 	lxqt-qtplugin    \
-	mesa-utils       \
 	qt6ct            \
 	qt6-tools        \
-	vulkan-tools     \
 	wget             \
 	xorg-server-xvfb \
 	zsync

--- a/useful-tools/demo/vkcube-glxgears-appimage.sh
+++ b/useful-tools/demo/vkcube-glxgears-appimage.sh
@@ -24,7 +24,6 @@ export PATH_MAPPING='
 
 pacman -Syu --noconfirm \
 	base-devel       \
-	curl             \
 	git              \
 	libxcb           \
 	libxcursor       \

--- a/useful-tools/demo/zink-vkcube-glxgears-appimage.sh
+++ b/useful-tools/demo/zink-vkcube-glxgears-appimage.sh
@@ -26,7 +26,6 @@ export PATH_MAPPING='
 
 pacman -Syu --noconfirm \
 	base-devel       \
-	curl             \
 	git              \
 	libxcb           \
 	libxcursor       \

--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -565,6 +565,10 @@ _determine_what_to_deploy() {
 					DEPLOY_QT_WEB_ENGINE=${DEPLOY_QT_WEB_ENGINE:-1}
 					DEPLOY_ELECTRON=${DEPLOY_ELECTRON:-1}
 					;;
+				*libgtk-x11-*.so*)
+					DEPLOY_GTK=${DEPLOY_GTK:-1}
+					GTK_DIR=gtk-2.0
+					;;
 				*libgtk-3*.so*)
 					DEPLOY_GTK=${DEPLOY_GTK:-1}
 					GTK_DIR=gtk-3.0


### PR DESCRIPTION
gtk2 demo has no icon unlike gtk3 and 4. 

TODO: Request gtk2-ng to create a logo.