### PR TITLE
OpenTubeX now officially uses Anylinux AppImages

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [OpenRCT2](https://github.com/pkgforge-dev/OpenRCT2-AppImage-Enhanced) |
 | [OpenSWE1R](https://github.com/pkgforge-dev/OpenSWE1R-AppImage) |
 | [OpenTTD](https://github.com/pkgforge-dev/OpenTTD-AppImage) |
-| [OpenTubeX](https://github.com/pkgforge-dev/OpenTubeX-Appimage-Enhanced) |
 | [OpenTyrian2000](https://github.com/pkgforge-dev/OpenTyrian2000-AppImage) |
 | [OpenXRay](https://github.com/pkgforge-dev/OpenXRay-AppImage) |
 | [OptiImage](https://github.com/pkgforge-dev/OptiImage-AppImage) |
@@ -460,6 +459,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [GPU-T](https://github.com/lseurttyuu/GPU-T) |
 | [interstellar](https://github.com/interstellar-app/interstellar) |
 | [lba2-classic-community](https://github.com/LBALab/lba2-classic-community) |
+| [OpenTubeX](https://github.com/OpenTubeX/OpenTubeX) |
 | [PPSSPP](https://github.com/hrydgard/PPSSPP) |
 | [QDash](https://git.crueter.xyz/QFRC/QDash) |
 | [RSS Guard](https://github.com/martinrotter/rssguard) |


### PR DESCRIPTION
Since [this release](https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.25.4-beta) OpenTubeX uses Anylinux AppImages for arm64 and amd64, so our repository is no longer needed and should be archived.