### PR TITLE
fix: prefer active ALT NVIDIA libraries in AppImages

### DIFF
--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -2351,6 +2351,12 @@ _add_apprun() {
 	export PATH=$APPDIR/bin:$PATH
 	export ARG0 APPDIR PATH
 
+	# HACK: Preserve ALT Linux's NVIDIA selection until sharun respects ld.so.cache order.
+	if [ -d /etc/libnvidiacurrent ]; then
+	        SHARUN_EXTRA_LIBRARY_PATH=/etc/libnvidiacurrent${SHARUN_EXTRA_LIBRARY_PATH:+:$SHARUN_EXTRA_LIBRARY_PATH}
+	        export SHARUN_EXTRA_LIBRARY_PATH
+	fi
+
 	# Allow users to set env variables for specific AppImage
 	# This feature only works with the uruntime
 	if [ "$1" = '--appimage-add-env' ]; then


### PR DESCRIPTION
ALT Linux has several Nvidia driver branches at the same time—currently 390, 470, 580, and 595. The /etc/libnvidiacurrent directory contains the ones loaded by the system; this fixes the issue where AppImage tries to load a library from the 595 drivers on a graphics card running the 580 drivers.