### PR TITLE
docs: drop dead repos and fix renamed links

### DIFF
--- a/.github/repos.stats
+++ b/.github/repos.stats
@@ -31,7 +31,7 @@ Bitwarden-AppImage-Enhanced: 125
 Blender-AppImage: 1330
 Brave-Origin-AppImage: 1121
 Bulky-AppImage: 918
-CDogs-SDL-AppImage: 510
+C-Dogs_SDL-AppImage: 510
 CLK-AppImage: 330
 Cannonball-AppImage: 550
 Cartridges-AppImage: 1157
@@ -47,15 +47,15 @@ Claude-Desktop-AppImage: 41
 Claws-Mail-AppImage: 82
 Clementine-AppImage: 1965
 CloneHero-AppImage: 18
-ClownMDEmu-AppImage: 526
+ClownMDEmu-AppImage-Enhanced: 526
 CollaboraOffice-AppImage: 949
 Collision-AppImage: 1574
 Commander-Genius-AppImage: 395
 Constrict-AppImage: 87
 CopyQ-AppImage: 623
-CorsixTH-AppImage: 500
+CorsixTH-AppImage-Enhanced: 500
 Crispy-Doom-AppImage: 385
-CroMagRally-AppImage: 437
+CroMagRally-AppImage-Enhanced: 437
 Cromite-AppImage: 6722
 Cuberite-AppImage: 363
 Cubyz-AppImage: 96
@@ -102,7 +102,7 @@ Flacon-AppImage-Enhanced: 120
 Flashrom-AppImage: 89
 Flycast-AppImage-Enhanced: 823
 Foobillardpp-AppImage: 373
-FreeTube-Appimage: 2010
+FreeTube-Appimage-Enhanced: 2010
 Fretboard-AppImage: 652
 GCAP2025-AppImage: 217
 GCAP2026-AppImage: 225
@@ -119,7 +119,7 @@ Gearlynx-AppImage: 316
 Gearsystem-AppImage: 595
 Ghostscript-AppImage: 3
 Ghostship-AppImage-Enhanced: 1265
-GitHub-Desktop-AppImage-Enhanced: 134
+GitHub-Desktop-Plus-AppImage-Enhanced: 134
 Gnome-Calculator-AppImage: 2878
 Gnome-System-Monitor-AppImage: 1114
 Gnome-Text-Editor-AppImage: 1169
@@ -159,7 +159,7 @@ Kid3-AppImage: 1615
 Knights-AppImage: 288
 KolourPaint-AppImage: 309
 Kronos-AppImage: 1067
-LMMS-AppImage: 586
+LMMS-AppImage-Enhanced: 586
 Libation-AppImage: 3461
 LibreCAD-AppImage: 546
 LibreWolf-AppImage-Enhanced: 761

--- a/.github/repos.stats.bytotal
+++ b/.github/repos.stats.bytotal
@@ -48,7 +48,7 @@ Extension-Manager-AppImage: 2127
 kdenlive-AppImage-Enhanced: 2091
 Audacity-AppImage-Enhanced: 2058
 Gapless-AppImage: 2012
-FreeTube-Appimage: 2010
+FreeTube-Appimage-Enhanced: 2010
 Clementine-AppImage: 1965
 EasyTAG-AppImage: 1942
 Qimgv-AppImage: 1940
@@ -194,7 +194,7 @@ PokeMMO-AppImage: 597
 Gearsystem-AppImage: 595
 vcmi-AppImage: 593
 VeraCrypt-AppImage: 592
-LMMS-AppImage: 586
+LMMS-AppImage-Enhanced: 586
 yt-dlp-AppImage: 581
 Rednukem-AppImage: 576
 Qmmp-AppImage: 575
@@ -216,7 +216,7 @@ Stella-AppImage: 534
 SUPER-ZSNES-AppImage: 531
 BasiliskII-AppImage-Enhanced: 531
 OpenTyrian2000-AppImage: 528
-ClownMDEmu-AppImage: 526
+ClownMDEmu-AppImage-Enhanced: 526
 dhewm3-AppImage: 523
 DarkPlaces-AppImage: 522
 Awakened-POE-Trade-AppImage-Enhanced: 520
@@ -225,13 +225,13 @@ KeePassXC-AppImage-Enhanced: 516
 Geargrafx-AppImage: 514
 vokoscreenNG-AppImage: 512
 Daggerfall-Unity-AppImage: 510
-CDogs-SDL-AppImage: 510
+C-Dogs_SDL-AppImage: 510
 Defold-AppImage: 509
 OpenRCT2-AppImage-Enhanced: 507
 Protontricks-AppImage: 504
 Signal-AppImage-Enhanced: 503
 PCSX2-AppImage-Enhanced: 501
-CorsixTH-AppImage: 500
+CorsixTH-AppImage-Enhanced: 500
 Mini-vMac-AppImage: 496
 RSDKv3-AppImage: 492
 PCSX-Redux-AppImage-Enhanced: 492
@@ -250,7 +250,7 @@ Rigs-of-Rods-AppImage: 449
 Iris-AppImage-Enhanced: 447
 QTerminal-AppImage: 445
 Supermariowar-AppImage: 437
-CroMagRally-AppImage: 437
+CroMagRally-AppImage-Enhanced: 437
 RSDKv4-AppImage: 436
 Exult-AppImage: 436
 Play-AppImage-Enhanced: 428
@@ -368,7 +368,7 @@ tachoparser-AppImage: 140
 Dillo-AppImage: 140
 Denise-AppImage: 140
 Slack-AppImage: 139
-GitHub-Desktop-AppImage-Enhanced: 134
+GitHub-Desktop-Plus-AppImage-Enhanced: 134
 ClassicImageViewer-AppImage-Enhanced: 130
 OCRmyPDF-AppImage: 129
 lba2-classic-community-AppImage: 127

--- a/.github/repos.stats.diff
+++ b/.github/repos.stats.diff
@@ -63,7 +63,7 @@ Quickshell-AppImage: 7
 Mousai-AppImage: 7
 Luanti-AppImage: 7
 Haruna-AppImage: 7
-FreeTube-Appimage: 7
+FreeTube-Appimage-Enhanced: 7
 DuckStation-GPL-AppImage-Enhanced: 7
 DeSmuME-AppImage: 7
 BigPEmu-AppImage: 7
@@ -100,7 +100,7 @@ Eyedropper-AppImage: 5
 ExtremeTuxRacer-AppImage: 5
 DOSBox-Pure-Unleashed-AppImage: 5
 DNZHRecomp-AppImage: 5
-CorsixTH-AppImage: 5
+CorsixTH-AppImage-Enhanced: 5
 Clementine-AppImage: 5
 Audacity-AppImage-Enhanced: 5
 Asphyxia-CORE-AppImage: 5
@@ -140,7 +140,7 @@ EasyTAG-AppImage: 4
 DevilutionX-AppImage-Enhanced: 4
 DOOM64EXUltra-AppImage: 4
 D2X-Rebirth-AppImage: 4
-CroMagRally-AppImage: 4
+CroMagRally-AppImage-Enhanced: 4
 CopyQ-AppImage: 4
 Audio-Sharing-AppImage: 4
 Akhenaten-AppImage: 4
@@ -321,7 +321,7 @@ KMines-AppImage: 1
 KMahjongg-AppImage: 1
 Flacon-AppImage-Enhanced: 1
 Clapper-AppImage: 1
-CDogs-SDL-AppImage: 1
+C-Dogs_SDL-AppImage: 1
 BetterMediaInfo-AppImage-Enhanced: 1
 AAAAXY-AppImage-Enhanced: 1
 xournalpp-AppImage-Enhanced: 0
@@ -396,17 +396,17 @@ Mini-vMac-AppImage: 0
 ManiaDrive-AppImage: 0
 MESA-AppImage: 0
 MATE-Calculator-AppImage: 0
-LMMS-AppImage: 0
+LMMS-AppImage-Enhanced: 0
 KTouch-AppImage: 0
 KCalc-AppImage: 0
-GitHub-Desktop-AppImage-Enhanced: 0
+GitHub-Desktop-Plus-AppImage-Enhanced: 0
 Ghostscript-AppImage: 0
 Dwarf-Fortress-AppImage: 0
 Dorion-AppImage-Enhanced: 0
 Cursor-AppImage-enhanced: 0
 Constrict-AppImage: 0
 Commander-Genius-AppImage: 0
-ClownMDEmu-AppImage: 0
+ClownMDEmu-AppImage-Enhanced: 0
 CloneHero-AppImage: 0
 Claws-Mail-AppImage: 0
 Citron-AppImage: 0

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [Cartridges](https://github.com/pkgforge-dev/Cartridges-AppImage) |
 | [CatacombGL](https://github.com/pkgforge-dev/CatacombGL-AppImage) |
 | [Catfish](https://github.com/pkgforge-dev/Catfish-AppImage) |
-| [C-Dogs_SDL](https://github.com/pkgforge-dev/CDogs-SDL-AppImage) |
+| [C-Dogs_SDL](https://github.com/pkgforge-dev/C-Dogs_SDL-AppImage) |
 | [Cemu](https://github.com/pkgforge-dev/Cemu-AppImage-Enhanced) |
 | [Cine](https://github.com/pkgforge-dev/Cine-AppImage) |
 | [Clapper](https://github.com/pkgforge-dev/Clapper-AppImage) |
@@ -90,16 +90,16 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [Clementine](https://github.com/pkgforge-dev/Clementine-AppImage) |
 | [Clock Signal](https://github.com/pkgforge-dev/CLK-AppImage) |
 | [CloneHero](https://github.com/pkgforge-dev/CloneHero-AppImage) |
-| [ClownMDEmu](https://github.com/pkgforge-dev/ClownMDEmu-AppImage) |
+| [ClownMDEmu](https://github.com/pkgforge-dev/ClownMDEmu-AppImage-Enhanced) |
 | [CollaboraOffice](https://github.com/pkgforge-dev/CollaboraOffice-AppImage) |
 | [Collision](https://github.com/pkgforge-dev/Collision-AppImage) |
 | [Commander-Genius](https://github.com/pkgforge-dev/Commander-Genius-AppImage) |
 | [Constrict](https://github.com/pkgforge-dev/Constrict-AppImage) |
 | [Contour](https://github.com/pkgforge-dev/contour-AppImage) |
 | [CopyQ](https://github.com/pkgforge-dev/CopyQ-AppImage) |
-| [CorsixTH](https://github.com/pkgforge-dev/CorsixTH-AppImage) |
+| [CorsixTH](https://github.com/pkgforge-dev/CorsixTH-AppImage-Enhanced) |
 | [Crispy Doom](https://github.com/pkgforge-dev/Crispy-Doom-AppImage) |
-| [CroMagRally](https://github.com/pkgforge-dev/CroMagRally-AppImage) |
+| [CroMagRally](https://github.com/pkgforge-dev/CroMagRally-AppImage-Enhanced) |
 | [Cromite](https://github.com/pkgforge-dev/Cromite-AppImage) |
 | [Cuberite](https://github.com/pkgforge-dev/Cuberite-AppImage) |
 | [Cubyz](https://github.com/pkgforge-dev/Cubyz-AppImage) |
@@ -155,7 +155,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [foot](https://github.com/pkgforge-dev/foot-AppImage) |
 | [fooyin](https://github.com/pkgforge-dev/fooyin-AppImage) |
 | [freac](https://github.com/pkgforge-dev/freac-AppImage-Enhanced) |
-| [FreeTube](https://github.com/pkgforge-dev/FreeTube-Appimage) |
+| [FreeTube](https://github.com/pkgforge-dev/FreeTube-Appimage-Enhanced) |
 | [Fretboard](https://github.com/pkgforge-dev/Fretboard-AppImage) |
 | [Galculator](https://github.com/pkgforge-dev/Galculator-AppImage) |
 | [gamescope](https://github.com/pkgforge-dev/gamescope-AppImage) |
@@ -174,7 +174,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [Ghostty](https://github.com/pkgforge-dev/ghostty-appimage) |
 | [gImageReader](https://github.com/pkgforge-dev/gImageReader-AppImage) |
 | [GIMP-and-PhotoGIMP](https://github.com/pkgforge-dev/GIMP-and-PhotoGIMP-AppImage) |
-| [GitHub Desktop](https://github.com/pkgforge-dev/GitHub-Desktop-AppImage-Enhanced) |
+| [GitHub Desktop Plus](https://github.com/pkgforge-dev/GitHub-Desktop-Plus-AppImage-Enhanced) |
 | [Gnome Calculator](https://github.com/pkgforge-dev/Gnome-Calculator-AppImage) |
 | [Gnome Pomodoro](https://github.com/pkgforge-dev/gnome-pomodoro-appimage) |
 | [Gnome System Monitor](https://github.com/pkgforge-dev/Gnome-System-Monitor-AppImage) |
@@ -234,7 +234,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [LibreWolf](https://github.com/pkgforge-dev/LibreWolf-AppImage-Enhanced) |
 | [LightZone](https://github.com/pkgforge-dev/LightZone-AppImage) |
 | [LinuxToys](https://github.com/pkgforge-dev/LinuxToys-AppImage) |
-| [LMMS](https://github.com/pkgforge-dev/LMMS-AppImage) |
+| [LMMS](https://github.com/pkgforge-dev/LMMS-AppImage-Enhanced) |
 | [LocalSend](https://github.com/pkgforge-dev/localsend-AppImage) |
 | [Luanti](https://github.com/pkgforge-dev/Luanti-AppImage) |
 | [Lutris](https://github.com/pkgforge-dev/Lutris-AppImage) |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [anki](https://github.com/pkgforge-dev/anki-AppImage) |
 | [Antigravity](https://github.com/pkgforge-dev/Antigravity-AppImage) |
 | [Antigravity IDE](https://github.com/pkgforge-dev/Antigravity-IDE-AppImage) |
-| [AppImageUpdate](https://github.com/pkgforge-dev/AppImageUpdate-Enhanced-Edition) |
 | [ares-emu](https://github.com/pkgforge-dev/ares-emu-appimage) |
 | [Arx Libertatis](https://github.com/pkgforge-dev/Arx-Libertatis-AppImage) |
 | [Asphyxia CORE](https://github.com/pkgforge-dev/Asphyxia-CORE-AppImage) |
@@ -82,7 +81,6 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [C-Dogs_SDL](https://github.com/pkgforge-dev/CDogs-SDL-AppImage) |
 | [Cemu](https://github.com/pkgforge-dev/Cemu-AppImage-Enhanced) |
 | [Cine](https://github.com/pkgforge-dev/Cine-AppImage) |
-| [Citron](https://github.com/pkgforge-dev/Citron-AppImage) |
 | [Clapper](https://github.com/pkgforge-dev/Clapper-AppImage) |
 | [ClassicImageViewer](https://github.com/pkgforge-dev/ClassicImageViewer-AppImage-Enhanced) |
 | [ClassiCube](https://github.com/pkgforge-dev/ClassiCube-AppImage) |
@@ -391,7 +389,6 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 | [Stoat](https://github.com/pkgforge-dev/Stoat-AppImage) |
 | [strawberry](https://github.com/pkgforge-dev/strawberry-AppImage) |
 | [Streamlink](https://github.com/pkgforge-dev/Streamlink-AppImage) |
-| [Sudachi](https://github.com/pkgforge-dev/Sudachi-AppImage) |
 | [Super Mario War](https://github.com/pkgforge-dev/Supermariowar-AppImage) |
 | [Supermodel](https://github.com/pkgforge-dev/Supermodel-AppImage) |
 | [SuperTux](https://github.com/pkgforge-dev/SuperTux-AppImage-Enhanced) |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For more useful documentation about Anylinux-AppImages, see the pages below:
 - [Size comparison](disk-usage-vs-flatpak.md)
 - [Build tools and scripts](useful-tools/)
 - [appimagetool](https://github.com/pkgforge-dev/appimagetool)
+- [AppImageUpdate](https://github.com/pkgforge-dev/AppImageUpdate)
 
 <!-- APPS_LIST_START -->
 


### PR DESCRIPTION
Every repo in the application list was checked against the API. Three are unusable and seven point at names that have since changed.

**Removed, no longer usable**

| Entry | Repo | Status |
|---|---|---|
| Citron | `Citron-AppImage` | HTTP 451, access blocked |
| Sudachi | `Sudachi-AppImage` | HTTP 404, gone |
| AppImageUpdate | `AppImageUpdate-Enhanced-Edition` | redirects to `AppImageUpdate-deprecated`, archived |

**Repointed at their current names.** These still worked through GitHub's redirect, so nothing was broken, but the links were stale.

| Was | Now |
|---|---|
| `CDogs-SDL-AppImage` | `C-Dogs_SDL-AppImage` |
| `ClownMDEmu-AppImage` | `ClownMDEmu-AppImage-Enhanced` |
| `CorsixTH-AppImage` | `CorsixTH-AppImage-Enhanced` |
| `CroMagRally-AppImage` | `CroMagRally-AppImage-Enhanced` |
| `FreeTube-Appimage` | `FreeTube-Appimage-Enhanced` |
| `GitHub-Desktop-AppImage-Enhanced` | `GitHub-Desktop-Plus-AppImage-Enhanced` |
| `LMMS-AppImage` | `LMMS-AppImage-Enhanced` |

The GitHub Desktop row is also relabelled to GitHub Desktop Plus, since that repo now packages a different upstream project rather than the same one renamed.

After both commits the list is 417 entries and every one returns 200 directly, with no redirects and nothing dead.

Not touched here: the three removed repos still appear in `.github/repos.stats`, `repos.stats.bytotal`, `repos.stats.diff` and `outdated.repos`. The stats workflow updates and appends but never removes, so those entries will persist. Citron alone accounts for 201034 downloads in the totals, so dropping them changes published figures and seemed a maintainer call.