### PR TITLE
always ignore pipewire and spa libs in strace mode

### DIFF
--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -1434,7 +1434,9 @@ _lib4bin_collect_strace() {
 		                                                     -e '/lib-dynload/d' \
 		                                                     -e '/_internal/d'   \
 		                                                     -e '/libncurses/d'  \
-		                                                     -e '/libcurses/d'
+		                                                     -e '/libcurses/d'   \
+		                                                     -e '/pipewire/d'    \
+		                                                     -e '/libspa/d'
 		)
 		rm -f "$dlopened"
 		[ -n "$out" ] || continue


### PR DESCRIPTION
Libraries like SDL will always try to dlopen pipewire on the host. Which means during strace mode pipewire is added incompletly (`DEPLOY_PIPEWIRE` is not triggered here), and this is bad, because old versions of SDL2 have a bug that it considers pipewire audio as working if the libpipewire library exists: 

https://github.com/libsdl-org/SDL/issues/15924

Later on quick-sharun patches away the libpipewire strings so that SDL doesn't go and try to use the pipewire of the host.

For pipewire to be properly deployed, the `DEPLOY_PIPEWIRE=1` var needs to be set **and the `pipewire-audio` package needs to be installed in the CI runner**, otherwise audio will be broken.

