### PR TITLE
add `cross-libc-dlopen` support

### DIFF
--- a/.github/workflows/build-demos.yml
+++ b/.github/workflows/build-demos.yml
@@ -27,6 +27,12 @@ jobs:
             script: vkcube-glxgears-appimage
           - arch: x86_64
             runs-on: ubuntu-24.04
+            script: vkcube-glxgears-host-drivers-appimage
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+            script: vkcube-glxgears-host-drivers-appimage
+          - arch: x86_64
+            runs-on: ubuntu-24.04
             script: gtk3-demo-appimage
           - arch: aarch64
             runs-on: ubuntu-24.04-arm
@@ -85,7 +91,7 @@ jobs:
 
       - name: Make AppImage
         run: |
-          sleep 5 # wait 5 seconds since github sometimes uses the file from the previous commit
+          sleep 10 # wait 10 seconds since github sometimes uses the file from the previous commit
           sh ./useful-tools/demo/${{ matrix.script }}.sh
 
       - name: Upload artifact

--- a/.github/workflows/build-demos.yml
+++ b/.github/workflows/build-demos.yml
@@ -75,6 +75,12 @@ jobs:
             script: sdl-demo-appimage
           - arch: x86_64
             runs-on: ubuntu-24.04
+            script: sdl-demo-host-drivers-appimage
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+            script: sdl-demo-host-drivers-appimage
+          - arch: x86_64
+            runs-on: ubuntu-24.04
             script: bun-demo-appimage
           - arch: aarch64
             runs-on: ubuntu-24.04-arm

--- a/.github/workflows/build-demos.yml
+++ b/.github/workflows/build-demos.yml
@@ -45,10 +45,10 @@ jobs:
             script: gtk4-demo-appimage
           - arch: x86_64
             runs-on: ubuntu-24.04
-            script: gtk4-demo-onlysoftware-appimage
+            script: gtk4-demo-host-drivers-appimage
           - arch: aarch64
             runs-on: ubuntu-24.04-arm
-            script: gtk4-demo-onlysoftware-appimage
+            script: gtk4-demo-host-drivers-appimage
           - arch: x86_64
             runs-on: ubuntu-24.04
             script: gtk2-demo-appimage
@@ -63,10 +63,10 @@ jobs:
             script: qt6-dbus-demo-appimage
           - arch: x86_64
             runs-on: ubuntu-24.04
-            script: qt6-dbus-demo-onlysoftware-appimage
+            script: qt6-dbus-demo-host-drivers-appimage
           - arch: aarch64
             runs-on: ubuntu-24.04-arm
-            script: qt6-dbus-demo-onlysoftware-appimage
+            script: qt6-dbus-demo-host-drivers-appimage
           - arch: x86_64
             runs-on: ubuntu-24.04
             script: sdl-demo-appimage

--- a/HOW-TO-MAKE-THESE.md
+++ b/HOW-TO-MAKE-THESE.md
@@ -372,6 +372,7 @@ Goes without saying that sharun handles all of this already on its own.
 See the ready-to-use demo scripts in [`useful-tools/demo/`](https://github.com/pkgforge-dev/Anylinux-AppImages/tree/main/useful-tools/demo):
 
 - [vkcube + glxgears](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/vkcube-glxgears-appimage.sh) - Bundles OpenGL and Vulkan test binaries
+- [vkcube + glxgears (host drivers)](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/vkcube-glxgears-host-drivers-appimage.sh) - Same as above but ships zero gpu drivers, those get loaded from the host system at runtime via `USE_HOST_DRIVERS_EXPERIMENTAL=1`
 - [gtk3-demo](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/gtk3-demo-appimage.sh) - Simple GTK3 application
 - [gtk4-demo](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/gtk4-demo-appimage.sh) - Simple GTK4 application
 - [gtk4-demo (software rendering)](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/gtk4-demo-onlysoftware-appimage.sh) - GTK4 demo using software-only rendering

--- a/HOW-TO-MAKE-THESE.md
+++ b/HOW-TO-MAKE-THESE.md
@@ -375,9 +375,9 @@ See the ready-to-use demo scripts in [`useful-tools/demo/`](https://github.com/p
 - [vkcube + glxgears (host drivers)](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/vkcube-glxgears-host-drivers-appimage.sh) - Same as above but ships zero gpu drivers, those get loaded from the host system at runtime via `USE_HOST_DRIVERS_EXPERIMENTAL=1`
 - [gtk3-demo](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/gtk3-demo-appimage.sh) - Simple GTK3 application
 - [gtk4-demo](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/gtk4-demo-appimage.sh) - Simple GTK4 application
-- [gtk4-demo (software rendering)](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/gtk4-demo-onlysoftware-appimage.sh) - GTK4 demo using software-only rendering
+- [gtk4-demo (host drivers)](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/gtk4-demo-host-drivers-appimage.sh) - GTK4 demo shipping zero gpu drivers, those get loaded from the host system at runtime via `USE_HOST_DRIVERS_EXPERIMENTAL=1`
 - [qt6-dbus-demo](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/qt6-dbus-demo-appimage.sh) - Qt6 application with D-Bus
-- [qt6-dbus-demo (software rendering)](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/qt6-dbus-demo-onlysoftware-appimage.sh) - Qt6 demo using software-only rendering
+- [qt6-dbus-demo (host drivers)](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/demo/qt6-dbus-demo-host-drivers-appimage.sh) - Qt6 demo shipping zero gpu drivers, those get loaded from the host system at runtime via `USE_HOST_DRIVERS_EXPERIMENTAL=1`
 
 ### Real-world examples
 

--- a/useful-tools/demo/gtk3-demo-appimage.sh
+++ b/useful-tools/demo/gtk3-demo-appimage.sh
@@ -12,6 +12,10 @@ export ICON=/usr/share/icons/hicolor/256x256/apps/gtk3-demo.png
 export DESKTOP=/usr/share/applications/gtk3-demo.desktop
 export OUTPATH=./dist
 export OUTNAME=gtk3-demo-"$ARCH".AppImage
+# gtk3 is not hardware accelerated, but supports GtkGLArea
+# to allow embedding opengl graphics inside gtk3 apps
+# very few apps use this, so lets just rely on the host drivers
+export USE_HOST_DRIVERS_EXPERIMENTAL=1
 
 pacman -Syu --noconfirm \
 	base-devel       \

--- a/useful-tools/demo/gtk4-demo-host-drivers-appimage.sh
+++ b/useful-tools/demo/gtk4-demo-host-drivers-appimage.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-# Demonstration that bundles a simple Qt6 app that interacts with dbus
-
-# this version deploys without hardware acceleration which results in a smaller
-# appimage, good for simple apps that do not really need hardware acceleration
+# Demonstration that bundles gtk4 demo app
+# without shipping a single gpu driver, the drivers are loaded from
+# the HOST system at runtime with the help of cross-libc-dlopen
+# https://github.com/pkgforge-dev/cross-libc-dlopen
 
 set -eux
 
@@ -11,18 +11,21 @@ ARCH="$(uname -m)"
 SHARUN="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/quick-sharun.sh"
 EXTRA_PACKAGES="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/get-debloated-pkgs.sh"
 
-export ICON=/usr/share/doc/qt6/global/template/images/Qt-logo.png
-export DESKTOP=DUMMY
-export MAIN_BIN=qdbusviewer6
+export ICON=/usr/share/icons/hicolor/scalable/apps/org.gtk.Demo4.svg
+export DESKTOP=/usr/share/applications/org.gtk.Demo4.desktop
 export OUTPATH=./dist
-export OUTNAME=Qt6+dbus-demo-onlysoftware-"$ARCH".AppImage
-# disable hardware accel
-export ALWAYS_SOFTWARE=1
+export OUTNAME=gtk4-demo-host-drivers-"$ARCH".AppImage
+export STARTUPWMCLASS=fuck.gnome
+export GTK_CLASS_FIX=1
+# ship zero gpu drivers, quick-sharun excludes everything the binaries
+# merely dlopen at runtime (dri plugins, gallium, vulkan layers, etc)
+# while libraries linked directly like libvulkan.so stay bundled
+export USE_HOST_DRIVERS_EXPERIMENTAL=1
 
 pacman -Syu --noconfirm \
 	base-devel       \
 	git              \
-	kvantum          \
+	gtk4-demos       \
 	libxcb           \
 	libxcursor       \
 	libxi            \
@@ -30,10 +33,7 @@ pacman -Syu --noconfirm \
 	libxkbcommon-x11 \
 	libxrandr        \
 	libxtst          \
-	lxqt-qtplugin    \
 	patchelf         \
-	qt6ct            \
-	qt6-tools        \
 	wget             \
 	xorg-server-xvfb \
 	zsync
@@ -48,7 +48,7 @@ echo "Bundling AppImage..."
 echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
 chmod +x ./quick-sharun
-./quick-sharun /usr/bin/qdbusviewer6
+./quick-sharun /usr/bin/gtk4-demo*
 
 ./quick-sharun --make-appimage
 

--- a/useful-tools/demo/qt6-dbus-demo-host-drivers-appimage.sh
+++ b/useful-tools/demo/qt6-dbus-demo-host-drivers-appimage.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-# Demonstration that bundles gtk4 demo app
-
-# this version deploys without hardware acceleration which results in a smaller
-# appimage, good for simple apps that do not really need hardware acceleration
+# Demonstration that bundles a simple Qt6 app that interacts with dbus
+# without shipping a single gpu driver, the drivers are loaded from
+# the HOST system at runtime with the help of cross-libc-dlopen
+# https://github.com/pkgforge-dev/cross-libc-dlopen
 
 set -eux
 
@@ -11,19 +11,20 @@ ARCH="$(uname -m)"
 SHARUN="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/quick-sharun.sh"
 EXTRA_PACKAGES="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/get-debloated-pkgs.sh"
 
-export ICON=/usr/share/icons/hicolor/scalable/apps/org.gtk.Demo4.svg
-export DESKTOP=/usr/share/applications/org.gtk.Demo4.desktop
+export ICON=/usr/share/doc/qt6/global/template/images/Qt-logo.png
+export DESKTOP=DUMMY
+export MAIN_BIN=qdbusviewer6
 export OUTPATH=./dist
-export OUTNAME=gtk4-demo-onlysoftware-"$ARCH".AppImage
-export STARTUPWMCLASS=fuck.gnome
-export GTK_CLASS_FIX=1
-# disable hardware accel
-export ALWAYS_SOFTWARE=1
+export OUTNAME=Qt6+dbus-demo-host-drivers-"$ARCH".AppImage
+# ship zero gpu drivers, quick-sharun excludes everything the binaries
+# merely dlopen at runtime (dri plugins, gallium, vulkan layers, etc)
+# while libraries linked directly like libvulkan.so stay bundled
+export USE_HOST_DRIVERS_EXPERIMENTAL=1
 
 pacman -Syu --noconfirm \
 	base-devel       \
 	git              \
-	gtk4-demos       \
+	kvantum          \
 	libxcb           \
 	libxcursor       \
 	libxi            \
@@ -31,7 +32,10 @@ pacman -Syu --noconfirm \
 	libxkbcommon-x11 \
 	libxrandr        \
 	libxtst          \
+	lxqt-qtplugin    \
 	patchelf         \
+	qt6ct            \
+	qt6-tools        \
 	wget             \
 	xorg-server-xvfb \
 	zsync
@@ -46,7 +50,7 @@ echo "Bundling AppImage..."
 echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
 chmod +x ./quick-sharun
-./quick-sharun /usr/bin/gtk4-demo*
+./quick-sharun /usr/bin/qdbusviewer6
 
 ./quick-sharun --make-appimage
 

--- a/useful-tools/demo/sdl-demo-host-drivers-appimage.sh
+++ b/useful-tools/demo/sdl-demo-host-drivers-appimage.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+
+# Demonstration that bundles a simple SDL2 application
+# without shipping a single gpu driver, the drivers are loaded from
+# the HOST system at runtime with the help of cross-libc-dlopen
+# https://github.com/pkgforge-dev/cross-libc-dlopen
+
+set -eux
+
+ARCH="$(uname -m)"
+SHARUN="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/quick-sharun.sh"
+EXTRA_PACKAGES="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/get-debloated-pkgs.sh"
+
+export ICON=https://raw.githubusercontent.com/libsdl-org/SDL/refs/heads/main/VisualC-GDK/logos/Logo150x150.png
+export DESKTOP=DUMMY
+export OUTPATH=./dist
+export OUTNAME=sdl2-demo-host-drivers-"$ARCH".AppImage
+export MAIN_BIN=SDL-demo
+# ship zero gpu drivers, quick-sharun excludes everything the binaries
+# merely dlopen at runtime (dri plugins, gallium, vulkan layers, etc)
+# while libraries linked directly like libvulkan.so stay bundled
+export USE_HOST_DRIVERS_EXPERIMENTAL=1
+
+pacman -Syu --noconfirm \
+	base-devel       \
+	git              \
+	libxcb           \
+	libxcursor       \
+	libxi            \
+	libxkbcommon     \
+	libxkbcommon-x11 \
+	libxrandr        \
+	libxtst          \
+	patchelf         \
+	sdl2             \
+	sdl2_ttf         \
+	fontconfig       \
+	ttf-dejavu       \
+	wget             \
+	xorg-server-xvfb \
+	zsync
+
+echo "Installing debloated packages..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
+chmod +x ./get-debloated-pkgs.sh
+./get-debloated-pkgs.sh --add-common --prefer-nano libdecor-mini
+
+echo "Building SDL-demo..."
+echo "---------------------------------------------------------------"
+cat > SDL-demo.c << 'EOF'
+#include <SDL.h>
+#include <SDL_ttf.h>
+#include <fontconfig/fontconfig.h>
+#include <string.h>
+#include <math.h>
+
+static char *find_font(void) {
+    FcInit();
+    FcPattern *pat = FcNameParse((const FcChar8 *)"sans");
+    FcConfigSubstitute(NULL, pat, FcMatchPattern);
+    FcDefaultSubstitute(pat);
+    FcResult res;
+    FcPattern *match = FcFontMatch(NULL, pat, &res);
+    FcPatternDestroy(pat);
+    if (match) {
+        FcChar8 *file;
+        if (FcPatternGetString(match, FC_FILE, 0, &file) == FcResultMatch) {
+            char *fp = strdup((char *)file);
+            FcPatternDestroy(match);
+            return fp;
+        }
+        FcPatternDestroy(match);
+    }
+    return NULL;
+}
+
+int main(int argc, char *argv[]) {
+    SDL_Window *win;
+    SDL_Renderer *ren;
+    TTF_Font *font;
+    SDL_Surface *surf;
+    SDL_Texture *tex;
+    SDL_Color white = {255, 255, 255};
+    SDL_Event ev;
+    int frame = 0, running = 1;
+
+    SDL_Init(SDL_INIT_VIDEO);
+    TTF_Init();
+    char *fp = find_font();
+    font = TTF_OpenFont(fp, 67);
+    free(fp);
+    surf = TTF_RenderUTF8_Blended(font, "67", white);
+    win = SDL_CreateWindow("SDL2 Demo", SDL_WINDOWPOS_UNDEFINED,
+                           SDL_WINDOWPOS_UNDEFINED, 640, 480, SDL_WINDOW_SHOWN);
+    ren = SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED);
+    tex = SDL_CreateTextureFromSurface(ren, surf);
+    SDL_FreeSurface(surf);
+
+    while (running) {
+        while (SDL_PollEvent(&ev))
+            if (ev.type == SDL_QUIT) running = 0;
+
+        int r = frame % 256, g = (frame * 2) % 256, b = (frame * 4) % 256;
+        SDL_SetRenderDrawColor(ren, r, g, b, 255);
+        SDL_RenderClear(ren);
+
+        double c = cos(frame * 0.025);
+        int tw, th;
+        SDL_QueryTexture(tex, NULL, NULL, &tw, &th);
+        int vw = fabs(c) * tw;
+        if (vw > 0) {
+            SDL_Rect dst = { (640 - vw) / 2, (480 - th) / 2, vw, th };
+            SDL_RenderCopyEx(ren, tex, NULL, &dst, 0, NULL,
+                             c < 0 ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE);
+        }
+
+        SDL_RenderPresent(ren);
+        SDL_Delay(16);
+        frame++;
+    }
+
+    SDL_DestroyTexture(tex);
+    SDL_DestroyRenderer(ren);
+    SDL_DestroyWindow(win);
+    TTF_CloseFont(font);
+    TTF_Quit();
+    SDL_Quit();
+    return 0;
+}
+EOF
+
+cc -O2 -o SDL-demo SDL-demo.c $(pkg-config --cflags --libs sdl2 SDL2_ttf fontconfig) -lm
+
+echo "Bundling AppImage..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
+chmod +x ./quick-sharun
+./quick-sharun ./SDL-demo
+
+./quick-sharun --make-appimage
+
+# test the final app
+./quick-sharun --test ./dist/*.AppImage

--- a/useful-tools/demo/vkcube-glxgears-host-drivers-appimage.sh
+++ b/useful-tools/demo/vkcube-glxgears-host-drivers-appimage.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# Demonstration that bundles vkcube (vulkan) and glxgears (opengl)
+# without shipping a single gpu driver, the drivers are loaded from
+# the HOST system at runtime using with the help of cross-libc-dlopen
+# https://github.com/pkgforge-dev/cross-libc-dlopen
+
+set -eux
+
+ARCH="$(uname -m)"
+SHARUN="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/quick-sharun.sh"
+EXTRA_PACKAGES="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/get-debloated-pkgs.sh"
+
+export CROSS_LIBC_DLOPEN_REPO="https://github.com/pkgforge-dev/cross-libc-dlopen.git"
+export ICON=DUMMY
+export DESKTOP=DUMMY
+export OUTPATH=./dist
+export OUTNAME=vkcube+glxgears-host-drivers-demo-"$ARCH".AppImage
+export MAIN_BIN=vkcube
+# ship zero gpu drivers, quick-sharun excludes everything the binaries
+# merely dlopen at runtime (dri plugins, gallium, vulkan layers, etc)
+# while libraries linked directly like libvulkan.so stay bundled
+export USE_HOST_DRIVERS_EXPERIMENTAL=1
+# vkmark is hardcoded to look in /usr/share/vkmark and /usr/lib/vkmark
+export PATH_MAPPING='
+	/usr/share/vkmark:${SHARUN_DIR}/share/vkmark
+	/usr/lib/vkmark:${SHARUN_DIR}/lib/vkmark
+'
+
+pacman -Syu --noconfirm \
+	base-devel       \
+	git              \
+	libxcb           \
+	libxcursor       \
+	libxi            \
+	libxkbcommon     \
+	libxkbcommon-x11 \
+	libxrandr        \
+	libxtst          \
+	mesa-utils       \
+	patchelf         \
+	vkmark           \
+	vulkan-tools     \
+	wget             \
+	xcb-util-wm      \
+	xorg-server-xvfb \
+	zsync
+
+echo "Installing debloated packages..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$EXTRA_PACKAGES" -O ./get-debloated-pkgs.sh
+chmod +x ./get-debloated-pkgs.sh
+./get-debloated-pkgs.sh --add-mesa --prefer-nano libdecor-mini
+
+echo "Bundling AppImage..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
+chmod +x ./quick-sharun
+./quick-sharun /usr/bin/vkcube /usr/*/vkmark /usr/bin/glxgears /usr/bin/eglgears*
+
+./quick-sharun --make-appimage
+
+# CI has no available gpu for the test
+pacman -S --noconfirm vulkan-swrast
+
+# test the final app
+./quick-sharun --test ./dist/*.AppImage

--- a/useful-tools/demo/vkcube-glxgears-host-drivers-appimage.sh
+++ b/useful-tools/demo/vkcube-glxgears-host-drivers-appimage.sh
@@ -11,7 +11,6 @@ ARCH="$(uname -m)"
 SHARUN="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/quick-sharun.sh"
 EXTRA_PACKAGES="https://raw.githubusercontent.com/${GITHUB_REPOSITORY%/*}/${GITHUB_REPOSITORY#*/}/refs/heads/main/useful-tools/get-debloated-pkgs.sh"
 
-export CROSS_LIBC_DLOPEN_REPO="https://github.com/pkgforge-dev/cross-libc-dlopen.git"
 export ICON=DUMMY
 export DESKTOP=DUMMY
 export OUTPATH=./dist

--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -1470,8 +1470,8 @@ _lib4bin_collect_strace() {
 		                                                     -e '/pipewire/d'    \
 		                                                     -e '/libspa/d'
 		)
-		# keep driver bits on the host, pairs with foreign dlopen in
-		# anylinux.so, ldd collected libs are unaffected. Note that every
+		# keep driver bits on the host, pairs with cross-libc-dlopen,
+		# ldd collected libs are unaffected. Note that every
 		# unwanted lib needs its own pattern, filtering a parent does not
 		# stop LD_DEBUG from listing its dependencies as separate lines
 		if [ "$USE_HOST_DRIVERS_EXPERIMENTAL" = 1 ]; then
@@ -1715,7 +1715,7 @@ _add_anylinux_lib() {
 	_echo "* anylinux.so successfully added!"
 }
 
-_add_foreign_dlopen_lib() {
+_add_cross_libc_dlopen_lib() {
 	[ "$USE_HOST_DRIVERS_EXPERIMENTAL" = 1 ] || return 0
 	target=$DST_LIB_DIR/cross-libc-dlopen.so
 	CLD_SRC=$TMPDIR/cross-libc-dlopen
@@ -3183,7 +3183,7 @@ _check_main_bin
 _map_paths_ld_preload_open
 _map_paths_binary_patch
 _add_anylinux_lib
-_add_foreign_dlopen_lib
+_add_cross_libc_dlopen_lib
 _check_window_class
 _add_gtk_class_fix
 

--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -46,7 +46,7 @@ DST_BIN_DIR=$APPDIR/bin
 SHARUN_BIN_DIR=$APPDIR/shared/bin
 MAIN_BIN=${MAIN_BIN##*/}
 
-SHARUN_LINK=${SHARUN_LINK:-https://github.com/pkgforge-dev/sharun/releases/download/2.2.7/sharun-$APPIMAGE_ARCH}
+SHARUN_LINK=${SHARUN_LINK:-https://github.com/pkgforge-dev/sharun/releases/download/2.3.0/sharun-$APPIMAGE_ARCH}
 ONELF_LINK=${ONELF_LINK:-https://github.com/QaidVoid/onelf/releases/latest/download/onelf-$APPIMAGE_ARCH-linux}
 HOOKSRC=${HOOKSRC:-https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/hooks}
 LD_PRELOAD_OPEN=${LD_PRELOAD_OPEN:-https://github.com/VHSgunzo/pathmap.git}
@@ -62,6 +62,7 @@ ANYLINUX_LIB=${ANYLINUX_LIB:-1}
 ANYLINUX_LIB_SOURCE=${ANYLINUX_LIB_SOURCE:-https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/lib/anylinux.c}
 GTK_CLASS_FIX=${GTK_CLASS_FIX:-0}
 GTK_CLASS_FIX_SOURCE=${GTK_CLASS_FIX_SOURCE:-https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/lib/gtk-class-fix.c}
+CROSS_LIBC_DLOPEN_REPO=${CROSS_LIBC_DLOPEN_REPO:-https://github.com/pkgforge-dev/cross-libc-dlopen.git}
 
 DEPLOY_DATADIR=${DEPLOY_DATADIR:-1}
 DEPLOY_LOCALE=${DEPLOY_LOCALE:-1}
@@ -261,6 +262,10 @@ _help_msg() {
 	                     applications use software rendering only, use this option
 	                     when you do not want hardware acceleration.
 	                     Will fail if application makes use of mesa during deployment.
+	  USE_HOST_DRIVERS_EXPERIMENTAL  Set to 1 to ship zero gpu drivers, we use the
+	                     host drivers instead via a experimental cross libc dlopen
+	                     feature (cross-libc-dlopen) that allows use host drivers
+	                     regardless of what libc they link against.
 	  STRACE_MODE      Sets the strace mode, the mechanism quick-sharun uses
 	                     to find and deploy the libraries the application loads
 	                     at runtime via dlopen. Enabled by default, set to 0 to
@@ -800,6 +805,16 @@ _make_deployment_array() {
 			"$LIB_DIR"/gconv/EUC-JP.so*   \
 			"$LIB_DIR"/gconv/EUC-KR.so*   \
 			"$LIB_DIR"/gconv/EUC-CN.so*
+	fi
+	# LIB32 builds always bundle their drivers, 32bit driver stacks are not
+	# something users have installed for these apps
+	if [ "$USE_HOST_DRIVERS_EXPERIMENTAL" = 1 ] && [ "$LIB32" != 1 ]; then
+		if [ "$ANYLINUX_LIB" != 1 ]; then
+			_err_msg "ERROR: USE_HOST_DRIVERS_EXPERIMENTAL requires ANYLINUX_LIB=1"
+			exit 1
+		fi
+		DEPLOY_OPENGL=0
+		DEPLOY_VULKAN=0
 	fi
 	if [ "$ALWAYS_SOFTWARE" = 1 ]; then
 		DEPLOY_OPENGL=0
@@ -1455,6 +1470,30 @@ _lib4bin_collect_strace() {
 		                                                     -e '/pipewire/d'    \
 		                                                     -e '/libspa/d'
 		)
+		# keep driver bits on the host, pairs with foreign dlopen in
+		# anylinux.so, ldd collected libs are unaffected. Note that every
+		# unwanted lib needs its own pattern, filtering a parent does not
+		# stop LD_DEBUG from listing its dependencies as separate lines
+		if [ "$USE_HOST_DRIVERS_EXPERIMENTAL" = 1 ]; then
+			out=$(printf '%s\n' "$out" | sed \
+				-e '/\/dri\//d'      \
+				-e '/_dri\.so/d'     \
+				-e '/gbm/d'          \
+				-e '/libgallium/d'   \
+				-e '/libglapi/d'     \
+				-e '/libLLVM/d'      \
+				-e '/libclang/d'     \
+				-e '/libSPIRV/d'     \
+				-e '/libsensors/d'   \
+				-e '/libelf\.so/d'   \
+				-e '/libdrm_/d'      \
+				-e '/libVkLayer/d'   \
+				-e '/libvulkan_/d'   \
+				-e '/libEGL_/d'      \
+				-e '/libGLX_/d'      \
+				-e '/_icd/d'         \
+				-e '/vdpau_/d')
+		fi
 		rm -f "$dlopened"
 		[ -n "$out" ] || continue
 		libs=$(printf '%s\n%s' "$libs" "$out")
@@ -1674,6 +1713,40 @@ _add_anylinux_lib() {
 	fi
 
 	_echo "* anylinux.so successfully added!"
+}
+
+_add_foreign_dlopen_lib() {
+	[ "$USE_HOST_DRIVERS_EXPERIMENTAL" = 1 ] || return 0
+	target=$DST_LIB_DIR/cross-libc-dlopen.so
+	CLD_SRC=$TMPDIR/cross-libc-dlopen
+
+	if [ ! -f "$target" ]; then
+		deps="git make"
+		if ! _is_cmd $deps; then
+			_err_msg "ERROR: Building cross-libc-dlopen requires $deps"
+			exit 1
+		fi
+
+		_echo "* Cloning $CROSS_LIBC_DLOPEN_REPO..."
+		rm -rf "$CLD_SRC"
+		git clone "$CROSS_LIBC_DLOPEN_REPO" "$CLD_SRC" && (
+			cd "$CLD_SRC"/src
+			# -fcf-protection=full is not supported on all gcc targets
+			# and has no functional benefit so it is removed
+			sed -i -e 's/ -fcf-protection=full//' Makefile
+			make
+		)
+
+		_echo "* Adding cross-libc-dlopen..."
+		for lib in cross-libc-dlopen.so gl-fwd.so egl-fwd.so gles-fwd.so; do
+			cp -v "$CLD_SRC"/src/"$lib" "$DST_LIB_DIR"
+			if ! grep -q "$lib" "$APPDIR"/.preload 2>/dev/null; then
+				echo "$lib" >> "$APPDIR"/.preload
+			fi
+		done
+		_echo "* cross-libc-dlopen successfully added!"
+	fi
+	:> "$APPDIR"/.foreign-dlopen-enabled
 }
 
 _add_gtk_class_fix() {
@@ -3110,6 +3183,7 @@ _check_main_bin
 _map_paths_ld_preload_open
 _map_paths_binary_patch
 _add_anylinux_lib
+_add_foreign_dlopen_lib
 _check_window_class
 _add_gtk_class_fix
 
@@ -3292,6 +3366,9 @@ for lib do case "$lib" in
 		fi
 		;;
 	*/libEGL_mesa.so*)
+		if [ "$USE_HOST_DRIVERS_EXPERIMENTAL" = 1 ]; then
+			continue
+		fi
 		src_glvnd_dir=/usr/share/glvnd/egl_vendor.d
 		dst_glvnd_dir=$APPDIR/share/glvnd/egl_vendor.d
 		_try_cp "$src_glvnd_dir" "$dst_glvnd_dir"
@@ -3299,6 +3376,9 @@ for lib do case "$lib" in
 		_try_cp /usr/share/drirc.d "$APPDIR"/share/drirc.d
 		;;
 	*/libvulkan.so*)
+		if [ "$USE_HOST_DRIVERS_EXPERIMENTAL" = 1 ]; then
+			continue
+		fi
 		src_vulkan_dir=/usr/share/vulkan/icd.d
 		dst_vulkan_dir=$APPDIR/share/vulkan/icd.d
 		if [ -d "$src_vulkan_dir" ] && [ ! -d "$dst_vulkan_dir" ]; then


### PR DESCRIPTION
https://github.com/pkgforge-dev/cross-libc-dlopen This will allow us to not need to ship the gpu drivers with every appimage we make. 

As result we save ~9 MiB in the final AppImage size.

This feature is **NOT** meant to be used with apps that need recent versions of OpenGL/Vulkan, so games and emulators will still ship drivers, this is only useful for simple hardware accelerated apps like most GTK4 apps.

