### PR TITLE
pin `appimagetool` version

### DIFF
--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -55,7 +55,7 @@ OUTPATH=${OUTPATH:-$PWD}
 DWARFS_COMP="${DWARFS_COMP:-zstd:level=22 -S26 -B6}"
 OPTIMIZE_LAUNCH=${OPTIMIZE_LAUNCH:-0}
 
-APPIMAGETOOL_LINK=${APPIMAGETOOL_LINK:-https://github.com/pkgforge-dev/appimagetool/releases/latest/download/appimagetool-$APPIMAGE_ARCH-linux}
+APPIMAGETOOL_LINK=${APPIMAGETOOL_LINK:-https://github.com/pkgforge-dev/appimagetool/releases/download/0.3.3/appimagetool-$APPIMAGE_ARCH-linux}
 APPIMAGETOOL=${APPIMAGETOOL:-$TMPDIR/appimagetool}
 
 ANYLINUX_LIB=${ANYLINUX_LIB:-1}


### PR DESCRIPTION
needed since we are working on supporting more cpu arches and next releases may have bugs.