### PR TITLE
gsettings: set GSETTINGS_BACKEND=keyfile only in portable mode

### DIFF
--- a/useful-tools/hooks/hook-system.md
+++ b/useful-tools/hooks/hook-system.md
@@ -66,6 +66,7 @@ Additional hooks can be placed in `$APPDIR/bin` and will be used automatically.
 * `HOSTPATH`      - The original value of `PATH` before `$APPDIR/bin` is added to `PATH`.
 * `APPDIR`        - The directory where the `AppRun` is located. **We guarantee this variable to be set even when the AppImage is extracted.**
 * `ARG0`          - Equivalent to `ARGV0` in the [AppImage runtime](https://docs.appimage.org/packaging-guide/environment-variables.html#id2). We always unset `ARGV0` because **it causes a ton of issues** [1](https://github.com/AppImage/AppImageKit/issues/852) [2](https://github.com/pkgforge-dev/ghostty-appimage/issues/20).
+* `APPIMAGE_PORTABLE_MODE` - Set to `1` by the uruntime when any AppImage portable dir (home, share, config, cache) is in use.
 
 * `BINDIR`    - Value of `XDG_BIN_HOME` or if not set; `~/.local/bin`.
 * `DATADIR`   - Value of `XDG_DATA_HOME` or if not set; `~/.local/share`.

--- a/useful-tools/lib/anylinux.c
+++ b/useful-tools/lib/anylinux.c
@@ -9,6 +9,10 @@
  * be inherited by other processes launched by the appimage in portable mode
  * causing them to start using the fake .home dir instead of the real home
  *
+ * It also sets GSETTINGS_BACKEND=keyfile when portable mode is in use, so
+ * gsettings are stored inside the portable dirs, while keeping the host
+ * backend (dconf) otherwise
+ *
  * It also offers the option to change argv0 of the running binary
  *
  * It also offers the ability to block specific libraries from being loaded via dlopen
@@ -80,6 +84,35 @@ static void spoof_argv0(int argc, char **argv) {
 // we save both here and construct a PATH with APPDIR/bin first at exec time.
 static char saved_appdir[PATH_MAX] = "";
 static char saved_path[PATH_MAX] = "";
+
+// Portable mode is active when the runtime redirected HOME/XDG dirs into
+// the portable dirs. New runtimes set APPIMAGE_PORTABLE_MODE, older ones
+// only leave the REAL_* vars behind, so fall back to those.
+static int portable_mode_active(void) {
+	if (getenv("APPIMAGE_PORTABLE_MODE"))
+		return 1;
+	return getenv("REAL_HOME") != NULL ||
+	       getenv("REAL_XDG_DATA_HOME") != NULL ||
+	       getenv("REAL_XDG_CONFIG_HOME") != NULL ||
+	       getenv("REAL_XDG_CACHE_HOME") != NULL;
+}
+
+// Only set the keyfile backend in portable mode so gsettings stay inside the
+// portable config dir. Outside portable mode nothing is set: apps must use
+// the host backend (dconf) and terminals must not leak it into user shells.
+// The injected value must never reach external processes, which get their
+// real HOME/XDG dirs restored, see create_cleaned_env().
+static int injected_gsettings_keyfile = 0;
+
+__attribute__((constructor))
+static void init_gsettings_backend(void) {
+	if (!portable_mode_active() || getenv("GSETTINGS_BACKEND"))
+		return; // not portable, or the user set their own backend: keep it
+	if (setenv("GSETTINGS_BACKEND", "keyfile", 1) == 0) {
+		injected_gsettings_keyfile = 1;
+		DEBUG_PRINT("Portable mode: set GSETTINGS_BACKEND=keyfile\n");
+	}
+}
 
 __attribute__((constructor))
 static void capture_appdir_and_path(void) {
@@ -302,6 +335,13 @@ static char* const* create_cleaned_env(char* const* original_env) {
 					break;
 				}
 			}
+		}
+		// our injected keyfile backend must not leak into external processes,
+		// they run with the real HOME/XDG dirs and host backend restored
+		if (injected_gsettings_keyfile &&
+		    strcmp(original_env[i], "GSETTINGS_BACKEND=keyfile") == 0) {
+			DEBUG_PRINT("Unset GSETTINGS_BACKEND (injected keyfile) for external process\n");
+			should_copy = 0;
 		}
 		if (should_copy) {
 			new_env[new_env_index] = strdup(original_env[i]);

--- a/useful-tools/lib/anylinux.c
+++ b/useful-tools/lib/anylinux.c
@@ -86,6 +86,17 @@ static void spoof_argv0(int argc, char **argv) {
 static char saved_appdir[PATH_MAX] = "";
 static char saved_path[PATH_MAX] = "";
 
+// vars the runtime redirects in portable mode, real values saved in REAL_*
+static const struct {
+	const char *real_var;
+	const char *var;
+} portable_vars[] = {
+	{ "REAL_XDG_DATA_HOME",   "XDG_DATA_HOME"   },
+	{ "REAL_XDG_CONFIG_HOME", "XDG_CONFIG_HOME" },
+	{ "REAL_XDG_CACHE_HOME",  "XDG_CACHE_HOME"  },
+	{ "REAL_HOME",            "HOME"            },
+};
+
 // Portable mode is active when the runtime redirected HOME/XDG dirs into
 // the portable dirs. New runtimes set APPIMAGE_PORTABLE_MODE (any value
 // other than 1 forces it off), older ones only leave the REAL_* vars
@@ -93,11 +104,11 @@ static char saved_path[PATH_MAX] = "";
 static int portable_mode_active(void) {
 	const char *v = getenv("APPIMAGE_PORTABLE_MODE");
 	if (v)
-		return strcmp(v, "1") == 0;
-	return getenv("REAL_HOME") != NULL ||
-	       getenv("REAL_XDG_DATA_HOME") != NULL ||
-	       getenv("REAL_XDG_CONFIG_HOME") != NULL ||
-	       getenv("REAL_XDG_CACHE_HOME") != NULL;
+		return strcmp(v, "1") == 0; // an explicit value wins
+	for (size_t i = 0; i < sizeof(portable_vars) / sizeof(portable_vars[0]); i++)
+		if (getenv(portable_vars[i].real_var))
+			return 1;
+	return 0;
 }
 
 // Set the keyfile backend only in portable mode and only when it is empty,
@@ -370,59 +381,36 @@ static int is_external_process(const char *filename) {
 	return external;
 }
 
+
 static void restore_portable_dirs(void) {
-	if (!portable_mode_active()) {
-		// the portable cache is not in use, so AppRun.lib moved
-		// XDG_CACHE_HOME to a dedicated location: give host processes
-		// the original cache back
-		const char *use_host_cache = getenv("USE_HOST_XDG_CACHE_HOME");
-		if (!use_host_cache || strcmp(use_host_cache, "1") != 0) {
-			const char *host_cache = getenv("HOST_XDG_CACHE_HOME");
-			if (host_cache && *host_cache) {
-				if (setenv("XDG_CACHE_HOME", host_cache, 1) == 0)
-					DEBUG_PRINT("Restored XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
+	if (portable_mode_active()) {
+		// HOME/XDG dirs were redirected into the portable dirs, restore
+		// the real values for host processes
+		for (size_t i = 0; i < sizeof(portable_vars) / sizeof(portable_vars[0]); i++) {
+			const char *real = getenv(portable_vars[i].real_var);
+			if (real && *real) {
+				if (setenv(portable_vars[i].var, real, 1) == 0)
+					DEBUG_PRINT("Restored %s to %s\n", portable_vars[i].var, real);
 				else
-					DEBUG_PRINT("Failed to restore XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
+					DEBUG_PRINT("Failed to restore %s to %s\n", portable_vars[i].var, real);
 			}
 		}
 		return;
 	}
 
-	// HOME/XDG dirs were redirected into the portable dirs, restore the
-	// real values for host processes
-	const char *real_data = getenv("REAL_XDG_DATA_HOME");
-	if (real_data && *real_data) {
-		if (setenv("XDG_DATA_HOME", real_data, 1) == 0)
-			DEBUG_PRINT("Restored XDG_DATA_HOME to %s\n", real_data);
-		else
-			DEBUG_PRINT("Failed to restore XDG_DATA_HOME to %s\n", real_data);
-	}
-
-	const char *real_config = getenv("REAL_XDG_CONFIG_HOME");
-	if (real_config && *real_config) {
-		if (setenv("XDG_CONFIG_HOME", real_config, 1) == 0)
-			DEBUG_PRINT("Restored XDG_CONFIG_HOME to %s\n", real_config);
-		else
-			DEBUG_PRINT("Failed to restore XDG_CONFIG_HOME to %s\n", real_config);
-	}
-
-	const char *real_cache = getenv("REAL_XDG_CACHE_HOME");
-	if (real_cache && *real_cache) {
-		if (setenv("XDG_CACHE_HOME", real_cache, 1) == 0)
-			DEBUG_PRINT("Restored XDG_CACHE_HOME to %s\n", real_cache);
-		else
-			DEBUG_PRINT("Failed to restore XDG_CACHE_HOME to %s\n", real_cache);
-	}
-
-	const char *real_home = getenv("REAL_HOME");
-	if (real_home && *real_home) {
-		if (setenv("HOME", real_home, 1) == 0)
-			DEBUG_PRINT("Restored HOME to %s\n", real_home);
-		else
-			DEBUG_PRINT("Failed to restore HOME to %s\n", real_home);
+	// the portable cache is not in use, so AppRun.lib moved XDG_CACHE_HOME
+	// to a dedicated location: give host processes the original cache back
+	const char *use_host_cache = getenv("USE_HOST_XDG_CACHE_HOME");
+	if (!use_host_cache || strcmp(use_host_cache, "1") != 0) {
+		const char *host_cache = getenv("HOST_XDG_CACHE_HOME");
+		if (host_cache && *host_cache) {
+			if (setenv("XDG_CACHE_HOME", host_cache, 1) == 0)
+				DEBUG_PRINT("Restored XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
+			else
+				DEBUG_PRINT("Failed to restore XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
+		}
 	}
 }
-
 static int spawn_common(posix_spawn_func_t fn,
 						const char *path, pid_t *pid,
 						const posix_spawn_file_actions_t *file_actions,

--- a/useful-tools/lib/anylinux.c
+++ b/useful-tools/lib/anylinux.c
@@ -87,11 +87,13 @@ static char saved_appdir[PATH_MAX] = "";
 static char saved_path[PATH_MAX] = "";
 
 // Portable mode is active when the runtime redirected HOME/XDG dirs into
-// the portable dirs. New runtimes set APPIMAGE_PORTABLE_MODE, older ones
-// only leave the REAL_* vars behind, so fall back to those.
+// the portable dirs. New runtimes set APPIMAGE_PORTABLE_MODE (any value
+// other than 1 forces it off), older ones only leave the REAL_* vars
+// behind, so fall back to those.
 static int portable_mode_active(void) {
-	if (getenv("APPIMAGE_PORTABLE_MODE"))
-		return 1;
+	const char *v = getenv("APPIMAGE_PORTABLE_MODE");
+	if (v)
+		return strcmp(v, "1") == 0;
 	return getenv("REAL_HOME") != NULL ||
 	       getenv("REAL_XDG_DATA_HOME") != NULL ||
 	       getenv("REAL_XDG_CONFIG_HOME") != NULL ||
@@ -369,6 +371,25 @@ static int is_external_process(const char *filename) {
 }
 
 static void restore_portable_dirs(void) {
+	if (!portable_mode_active()) {
+		// the portable cache is not in use, so AppRun.lib moved
+		// XDG_CACHE_HOME to a dedicated location: give host processes
+		// the original cache back
+		const char *use_host_cache = getenv("USE_HOST_XDG_CACHE_HOME");
+		if (!use_host_cache || strcmp(use_host_cache, "1") != 0) {
+			const char *host_cache = getenv("HOST_XDG_CACHE_HOME");
+			if (host_cache && *host_cache) {
+				if (setenv("XDG_CACHE_HOME", host_cache, 1) == 0)
+					DEBUG_PRINT("Restored XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
+				else
+					DEBUG_PRINT("Failed to restore XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
+			}
+		}
+		return;
+	}
+
+	// HOME/XDG dirs were redirected into the portable dirs, restore the
+	// real values for host processes
 	const char *real_data = getenv("REAL_XDG_DATA_HOME");
 	if (real_data && *real_data) {
 		if (setenv("XDG_DATA_HOME", real_data, 1) == 0)
@@ -391,19 +412,6 @@ static void restore_portable_dirs(void) {
 			DEBUG_PRINT("Restored XDG_CACHE_HOME to %s\n", real_cache);
 		else
 			DEBUG_PRINT("Failed to restore XDG_CACHE_HOME to %s\n", real_cache);
-	}
-
-	// we always set XDG_CACHE_HOME to a new location to prevent conflicts with
-	// the host cache, restore XDG_CACHE_HOME to the original value
-	const char *use_host_cache = getenv("USE_HOST_XDG_CACHE_HOME");
-	if (!use_host_cache || strcmp(use_host_cache, "1") != 0) {
-		const char *host_cache = getenv("HOST_XDG_CACHE_HOME");
-		if (host_cache && *host_cache) {
-			if (setenv("XDG_CACHE_HOME", host_cache, 1) == 0)
-				DEBUG_PRINT("Restored XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
-			else
-				DEBUG_PRINT("Failed to restore XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
-		}
 	}
 
 	const char *real_home = getenv("REAL_HOME");

--- a/useful-tools/lib/anylinux.c
+++ b/useful-tools/lib/anylinux.c
@@ -11,7 +11,8 @@
  *
  * It also sets GSETTINGS_BACKEND=keyfile when portable mode is in use, so
  * gsettings are stored inside the portable dirs, while keeping the host
- * backend (dconf) otherwise
+ * backend (dconf) otherwise, and never passes GSETTINGS_BACKEND to
+ * external processes
  *
  * It also offers the option to change argv0 of the running binary
  *
@@ -97,21 +98,16 @@ static int portable_mode_active(void) {
 	       getenv("REAL_XDG_CACHE_HOME") != NULL;
 }
 
-// Only set the keyfile backend in portable mode so gsettings stay inside the
-// portable config dir. Outside portable mode nothing is set: apps must use
-// the host backend (dconf) and terminals must not leak it into user shells.
-// The injected value must never reach external processes, which get their
-// real HOME/XDG dirs restored, see create_cleaned_env().
-static int injected_gsettings_keyfile = 0;
-
+// Set the keyfile backend only in portable mode and only when it is empty,
+// so gsettings stay inside the portable config dir while a user-provided
+// backend is kept as is. Outside portable mode nothing is set: apps use the
+// host backend (dconf) and terminals do not leak it into user shells.
 __attribute__((constructor))
 static void init_gsettings_backend(void) {
 	if (!portable_mode_active() || getenv("GSETTINGS_BACKEND"))
-		return; // not portable, or the user set their own backend: keep it
-	if (setenv("GSETTINGS_BACKEND", "keyfile", 1) == 0) {
-		injected_gsettings_keyfile = 1;
+		return;
+	if (setenv("GSETTINGS_BACKEND", "keyfile", 1) == 0)
 		DEBUG_PRINT("Portable mode: set GSETTINGS_BACKEND=keyfile\n");
-	}
 }
 
 __attribute__((constructor))
@@ -336,11 +332,10 @@ static char* const* create_cleaned_env(char* const* original_env) {
 				}
 			}
 		}
-		// our injected keyfile backend must not leak into external processes,
-		// they run with the real HOME/XDG dirs and host backend restored
-		if (injected_gsettings_keyfile &&
-		    strcmp(original_env[i], "GSETTINGS_BACKEND=keyfile") == 0) {
-			DEBUG_PRINT("Unset GSETTINGS_BACKEND (injected keyfile) for external process\n");
+		// external processes run with the real HOME/XDG dirs, they must
+		// also use the host gsettings backend: never pass GSETTINGS_BACKEND
+		if (strncmp(original_env[i], "GSETTINGS_BACKEND=", 18) == 0) {
+			DEBUG_PRINT("Unset GSETTINGS_BACKEND for external process\n");
 			should_copy = 0;
 		}
 		if (should_copy) {

--- a/useful-tools/lib/anylinux.c
+++ b/useful-tools/lib/anylinux.c
@@ -383,31 +383,18 @@ static int is_external_process(const char *filename) {
 
 
 static void restore_portable_dirs(void) {
-	if (portable_mode_active()) {
-		// HOME/XDG dirs were redirected into the portable dirs, restore
-		// the real values for host processes
-		for (size_t i = 0; i < sizeof(portable_vars) / sizeof(portable_vars[0]); i++) {
-			const char *real = getenv(portable_vars[i].real_var);
-			if (real && *real) {
-				if (setenv(portable_vars[i].var, real, 1) == 0)
-					DEBUG_PRINT("Restored %s to %s\n", portable_vars[i].var, real);
-				else
-					DEBUG_PRINT("Failed to restore %s to %s\n", portable_vars[i].var, real);
-			}
-		}
+	if (!portable_mode_active())
 		return;
-	}
-
-	// the portable cache is not in use, so AppRun.lib moved XDG_CACHE_HOME
-	// to a dedicated location: give host processes the original cache back
-	const char *use_host_cache = getenv("USE_HOST_XDG_CACHE_HOME");
-	if (!use_host_cache || strcmp(use_host_cache, "1") != 0) {
-		const char *host_cache = getenv("HOST_XDG_CACHE_HOME");
-		if (host_cache && *host_cache) {
-			if (setenv("XDG_CACHE_HOME", host_cache, 1) == 0)
-				DEBUG_PRINT("Restored XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
+	// HOME/XDG dirs were redirected into the portable dirs, restore the
+	// real values for host processes. The portable cache, if in use, is
+	// restored through REAL_XDG_CACHE_HOME like the rest.
+	for (size_t i = 0; i < sizeof(portable_vars) / sizeof(portable_vars[0]); i++) {
+		const char *real = getenv(portable_vars[i].real_var);
+		if (real && *real) {
+			if (setenv(portable_vars[i].var, real, 1) == 0)
+				DEBUG_PRINT("Restored %s to %s\n", portable_vars[i].var, real);
 			else
-				DEBUG_PRINT("Failed to restore XDG_CACHE_HOME to %s (from HOST_XDG_CACHE_HOME)\n", host_cache);
+				DEBUG_PRINT("Failed to restore %s to %s\n", portable_vars[i].var, real);
 		}
 	}
 }

--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -2799,6 +2799,7 @@ _add_hooks_library() {
 	# at the portable dirs, keep XDG_CACHE_HOME as is
 	if [ "$USE_HOST_XDG_CACHE_HOME" != 1 ] && [ -n "$APPIMAGE" ] \
 	   && [ "$APPIMAGE_PORTABLE_MODE" != 1 ]; then
+	        export HOST_XDG_CACHE_HOME="$CACHEDIR"
 	        _cache_dir=$CACHEDIR/AppImage-Cache
 	        if [ -d "$_cache_dir" ] || mkdir -p "$_cache_dir" 2>/dev/null; then
 	                export XDG_CACHE_HOME="$_cache_dir"

--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -1004,7 +1004,6 @@ _make_deployment_array() {
 		case "$GTK_DIR" in
 			*4*)
 				DEPLOY_OPENGL=${DEPLOY_OPENGL:-1}
-				echo 'GSETTINGS_BACKEND=keyfile' >> "$APPENV"
 				;;
 		esac
 

--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -1002,9 +1002,7 @@ _make_deployment_array() {
 			"$LIB_DIR"/gio/modules/libdconfsettings.so
 
 		case "$GTK_DIR" in
-			*4*)
-				DEPLOY_OPENGL=${DEPLOY_OPENGL:-1}
-				;;
+			*4*) DEPLOY_OPENGL=${DEPLOY_OPENGL:-1};;
 		esac
 
 		if [ "$DEPLOY_WEBKIT2GTK" = 1 ]; then
@@ -2795,20 +2793,23 @@ _add_hooks_library() {
 	# always change XDG_CACHE_HOME to our own dedicated location
 	# using the host XDG_CACHE_HOME has been a source of issues
 	# See: https://github.com/pkgforge-dev/Anylinux-AppImages/issues/657
-	# APPIMAGE_PORTABLE_MODE=1: the runtime already pointed the XDG dirs
-	# at the portable dirs, keep XDG_CACHE_HOME as is
-	if [ "$USE_HOST_XDG_CACHE_HOME" != 1 ] && [ -n "$APPIMAGE" ] \
-	   && [ "$APPIMAGE_PORTABLE_MODE" != 1 ]; then
-	        export HOST_XDG_CACHE_HOME="$CACHEDIR"
-	        _cache_dir=$CACHEDIR/AppImage-Cache
-	        if [ -d "$_cache_dir" ] || mkdir -p "$_cache_dir" 2>/dev/null; then
-	                export XDG_CACHE_HOME="$_cache_dir"
-	        fi
-	        # we still need to share thumbnails cache
-	        # since thubmanilers will place them at original location
-	        if [ ! -L "$_cache_dir"/thumbnails ] && mkdir -p "$CACHEDIR"/thumbnails 2>/dev/null; then
-	                ln -sfn "$CACHEDIR"/thumbnails "$_cache_dir"/thumbnails 2>/dev/null || :
-	        fi
+	if [ "$USE_HOST_XDG_CACHE_HOME" != 1 ] && [ -n "$APPIMAGE" ]; then
+	        case "$XDG_CACHE_HOME" in
+	                *"$APPIMAGE"*) # make sure we are not using the portable cache first
+	                        :
+	                        ;;
+	                *)
+	                        _cache_dir=$CACHEDIR/AppImage-Cache
+	                        if [ -d "$_cache_dir" ] || mkdir -p "$_cache_dir" 2>/dev/null; then
+	                                export XDG_CACHE_HOME="$_cache_dir"
+	                        fi
+	                        # we still need to share thumbnails cache
+	                        # since thubmanilers will place them at original location
+	                        if [ ! -L "$_cache_dir"/thumbnails ] && mkdir -p "$CACHEDIR"/thumbnails 2>/dev/null; then
+	                                ln -sfn "$CACHEDIR"/thumbnails "$_cache_dir"/thumbnails 2>/dev/null || :
+	                        fi
+	                        ;;
+	        esac
 	fi
 
 	err_msg(){

--- a/useful-tools/quick-sharun.sh
+++ b/useful-tools/quick-sharun.sh
@@ -2795,23 +2795,19 @@ _add_hooks_library() {
 	# always change XDG_CACHE_HOME to our own dedicated location
 	# using the host XDG_CACHE_HOME has been a source of issues
 	# See: https://github.com/pkgforge-dev/Anylinux-AppImages/issues/657
-	if [ "$USE_HOST_XDG_CACHE_HOME" != 1 ] && [ -n "$APPIMAGE" ]; then
-	        case "$XDG_CACHE_HOME" in
-	                *"$APPIMAGE"*) # make sure we are not using the portable cache first
-	                        :
-	                        ;;
-	                *)
-	                        _cache_dir=$CACHEDIR/AppImage-Cache
-	                        if [ -d "$_cache_dir" ] || mkdir -p "$_cache_dir" 2>/dev/null; then
-	                                export XDG_CACHE_HOME="$_cache_dir"
-	                        fi
-	                        # we still need to share thumbnails cache
-	                        # since thubmanilers will place them at original location
-	                        if [ ! -L "$_cache_dir"/thumbnails ] && mkdir -p "$CACHEDIR"/thumbnails 2>/dev/null; then
-	                                ln -sfn "$CACHEDIR"/thumbnails "$_cache_dir"/thumbnails 2>/dev/null || :
-	                        fi
-	                        ;;
-	        esac
+	# APPIMAGE_PORTABLE_MODE=1: the runtime already pointed the XDG dirs
+	# at the portable dirs, keep XDG_CACHE_HOME as is
+	if [ "$USE_HOST_XDG_CACHE_HOME" != 1 ] && [ -n "$APPIMAGE" ] \
+	   && [ "$APPIMAGE_PORTABLE_MODE" != 1 ]; then
+	        _cache_dir=$CACHEDIR/AppImage-Cache
+	        if [ -d "$_cache_dir" ] || mkdir -p "$_cache_dir" 2>/dev/null; then
+	                export XDG_CACHE_HOME="$_cache_dir"
+	        fi
+	        # we still need to share thumbnails cache
+	        # since thubmanilers will place them at original location
+	        if [ ! -L "$_cache_dir"/thumbnails ] && mkdir -p "$CACHEDIR"/thumbnails 2>/dev/null; then
+	                ln -sfn "$CACHEDIR"/thumbnails "$_cache_dir"/thumbnails 2>/dev/null || :
+	        fi
 	fi
 
 	err_msg(){


### PR DESCRIPTION
Fixes the environment leak reported in pkgforge-dev/ghostty-appimage#158 and supersedes the global `GSETTINGS_BACKEND=keyfile` default from #40.

## Problem

`quick-sharun.sh` baked `GSETTINGS_BACKEND=keyfile` into `$APPDIR/.env` at build time for GTK4 apps, so it was set unconditionally at runtime:
- terminal appimages (ghostty) leaked it into the shells they spawn, where `gsettings set` wrote to the keyfile instead of dconf
- non-portable apps saved their settings to `~/.config/glib-2.0/settings/keyfile` instead of the host dconf, unlike a native install

## Fix

Flip the logic from build time to runtime:
- `quick-sharun.sh` no longer writes `GSETTINGS_BACKEND` to `.env`
- `anylinux.c` sets `GSETTINGS_BACKEND=keyfile` in a constructor **only** when portable mode is active (`--appimage-portable-{home,share,config,cache}`), detected via `APPIMAGE_PORTABLE_MODE` (set by Anylinux-uruntime, companion PR pkgforge-dev/Anylinux-uruntime#1) with a `REAL_HOME`/`REAL_XDG_*` fallback for older runtimes — gsettings then stay inside the portable config dir
- it is set only when empty: a user-provided `GSETTINGS_BACKEND` is never touched, so the documented `dconf` override for system packaging keeps working
- `create_cleaned_env()` now always unsets `GSETTINGS_BACKEND` for external processes, which already get their real `HOME`/XDG dirs restored — spawned shells keep the host backend

## Verification

Compiled with `gcc -shared -fPIC -O2 -Wall -Wextra` (only the pre-existing `argc` warning), matrix from an LD_PRELOAD test harness:

| scenario | app itself | external child | internal child |
|---|---|---|---|
| non-portable | unset | unset | unset |
| portable (`APPIMAGE_PORTABLE_MODE=1`) | keyfile | unset | keyfile |
| portable (`REAL_HOME`, old runtime) | keyfile | unset | keyfile |
| portable + user `GSETTINGS_BACKEND=dconf` | dconf (kept) | unset | dconf (kept) |

`anylinux.c` is fetched from `main` at build time (`ANYLINUX_LIB_SOURCE`), so rebuilt appimages pick this up immediately; the `REAL_*` fallback means it already works with the uruntime currently embedded in appimagetool 0.3.6.

---
Requested by @Samueru-sama in the pi-discord agent session — transcript: https://talaria.qaidvoid.dev/api/sessions/2026-09-03T06-18-40-111Z_01a065eb-626f-76a2-b34d-5337020d5eb6/stream
